### PR TITLE
Extended prometheus scraping

### DIFF
--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -33,6 +33,14 @@ spec:
       hostPath:
         path: /var/log/pods
 
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+
   # Environment variables
   env:
   {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -59,6 +59,43 @@ spec:
       prometheus:
         config:
           scrape_configs:
+            - job_name: 'kubernetes-apiservers'
+              scrape_interval: 30s
+
+              kubernetes_sd_configs:
+                - role: endpoints
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+                  action: keep
+                  regex: default;kubernetes;https
+
+            - job_name: 'kubernetes-nodes'
+              scrape_interval: 30s
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+              kubernetes_sd_configs:
+                - role: node
+
+              relabel_configs:
+                # - action: labelmap
+                #   regex: __meta_kubernetes_node_label_(.+)
+                - target_label: __address__
+                  replacement: kubernetes.default.svc:443
+                - source_labels: [__meta_kubernetes_node_name]
+                  regex: (.+)
+                  target_label: __metrics_path__
+                  replacement: /api/v1/nodes/$$1/proxy/metrics
+
             - job_name: 'kubernetes-nodes-cadvisor'
               scrape_interval: 30s
               scheme: https
@@ -81,6 +118,95 @@ spec:
                   regex: (.+)
                   target_label: __metrics_path__
                   replacement: /api/v1/nodes/$$1/proxy/metrics/cadvisor
+
+            - job_name: 'kubernetes-service-endpoints'
+              scrape_interval: 30s
+              honor_labels: true
+
+              kubernetes_sd_configs:
+                - role: endpoints
+
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: true
+                - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape_slow]
+                  action: drop
+                  regex: true
+                - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+                  action: replace
+                  target_label: __scheme__
+                  regex: (https?)
+                - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+                  action: replace
+                  target_label: __address__
+                  regex: (.+?)(?::\d+)?;(\d+)
+                  replacement: $$1:$$2
+                # - action: labelmap
+                #   regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+                #   replacement: __param_$$1
+                # - action: labelmap
+                #   regex: __meta_kubernetes_service_label_(.+)
+                - source_labels: [__meta_kubernetes_namespace]
+                  action: replace
+                  target_label: namespace
+                - source_labels: [__meta_kubernetes_service_name]
+                  action: replace
+                  target_label: service
+                - source_labels: [__meta_kubernetes_pod_node_name]
+                  action: replace
+                  target_label: node
+
+            - job_name: 'kubernetes-pods'
+              scrape_interval: 30s
+              honor_labels: true
+
+              kubernetes_sd_configs:
+                - role: pod
+
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: true
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
+                  action: drop
+                  regex: true
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+                  action: replace
+                  regex: (https?)
+                  target_label: __scheme__
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+                  action: replace
+                  regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+                  replacement: '[$$2]:$$1'
+                  target_label: __address__
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+                  action: replace
+                  regex: (\d+);((([0-9]+?)(\.|$)){4})
+                  replacement: $$2:$$1
+                  target_label: __address__
+                # - action: labelmap
+                #   regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+                #   replacement: __param_$$1
+                # - action: labelmap
+                #   regex: __meta_kubernetes_pod_label_(.+)
+                - source_labels: [__meta_kubernetes_namespace]
+                  action: replace
+                  target_label: namespace
+                - source_labels: [__meta_kubernetes_pod_name]
+                  action: replace
+                  target_label: pod
+                - source_labels: [__meta_kubernetes_pod_phase]
+                  regex: Pending|Succeeded|Failed|Completed
+                  action: drop
 
     processors:
       batch:

--- a/helm/scripts/01_deploy_collectors.sh
+++ b/helm/scripts/01_deploy_collectors.sh
@@ -4,6 +4,9 @@
 newrelicOtlpEndpoint="otlp.eu01.nr-data.net:4317"
 
 ### Set variables
+declare -A nodeexporter
+nodeexporter["name"]="nodeexporter"
+nodeexporter["namespace"]="monitoring"
 
 # otelcollectors
 declare -A otelcollectors
@@ -16,6 +19,22 @@ otelcollectors["statefulsetPrometheusPort"]=8888
 ###################
 ### Deploy Helm ###
 ###################
+
+# nodeexporter
+# helm repo add bitnami https://charts.bitnami.com/bitnami
+helm upgrade ${nodeexporter[name]} \
+  --install \
+  --wait \
+  --debug \
+  --create-namespace \
+  --namespace ${nodeexporter[namespace]} \
+  --set tolerations[0].key="node-role.kubernetes.io/master" \
+  --set tolerations[0].operator="Exists" \
+  --set tolerations[0].effect="NoSchedule" \
+  --set tolerations[1].key="node-role.kubernetes.io/control-plane" \
+  --set tolerations[1].operator="Exists" \
+  --set tolerations[1].effect="NoSchedule" \
+  bitnami/node-exporter
 
 # otelcollector
 helm upgrade ${otelcollectors[name]} \

--- a/helm/scripts/01_deploy_collectors.sh
+++ b/helm/scripts/01_deploy_collectors.sh
@@ -4,6 +4,13 @@
 newrelicOtlpEndpoint="otlp.eu01.nr-data.net:4317"
 
 ### Set variables
+
+# kubestatemetrics
+declare -A kubestatemetrics
+kubestatemetrics["name"]="kubestatemetrics"
+kubestatemetrics["namespace"]="monitoring"
+
+# nodeexporter
 declare -A nodeexporter
 nodeexporter["name"]="nodeexporter"
 nodeexporter["namespace"]="monitoring"
@@ -20,8 +27,12 @@ otelcollectors["statefulsetPrometheusPort"]=8888
 ### Deploy Helm ###
 ###################
 
-# nodeexporter
+# Repositories
 # helm repo add bitnami https://charts.bitnami.com/bitnami
+# helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+# helm repo update
+
+# nodeexporter
 helm upgrade ${nodeexporter[name]} \
   --install \
   --wait \
@@ -34,7 +45,17 @@ helm upgrade ${nodeexporter[name]} \
   --set tolerations[1].key="node-role.kubernetes.io/control-plane" \
   --set tolerations[1].operator="Exists" \
   --set tolerations[1].effect="NoSchedule" \
-  bitnami/node-exporter
+  "bitnami/node-exporter"
+
+# kubestatemetrics
+helm upgrade ${kubestatemetrics[name]} \
+  --install \
+  --wait \
+  --debug \
+  --create-namespace \
+  --namespace ${kubestatemetrics[namespace]} \
+  --set autosharding.enabled=true \
+  "prometheus-community/kube-state-metrics"
 
 # otelcollector
 helm upgrade ${otelcollectors[name]} \


### PR DESCRIPTION
## Changes

- Prometheus scrape configurations for nodes,  endpoints and pods are added
- `node-exporter` is added
- `kube-state-metrics` is added
- Daemonset collector instances are configured to be deployed on master nodes