### PR TITLE
Added reference to existing secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,61 @@ helm upgrade ${otelcollectors[name]} \
 
 The cluster name that you define will be added as an additional attribute `k8s.cluster.name` to all of telemetry data which are collected by the collectors so that later, you can filter them out according to your various clusters.
 
+### Setting up license keys
+
+There are 2 ways to set your New Relic license keys:
+
+**Reference an existing secret**
+
+If you already have put your secrets into a Kubernetes secret within the same namespace as this Helm deployment's, you can reference that as follows:
+
+1. Define in `values.yaml`
+
+```yaml
+newrelic:
+  opsteam:
+    endpoint: "<NEW_RELIC_OTLP_ENDPOINT>"
+    licenseKey:
+      secretRef:
+        name: "<YOUR_EXISTING_SECRET>"
+        key: "<KEY_TO_LICENSE_KEY_WITHIN_THE_SECRET>"
+```
+
+2. Set per `helm --set`
+
+```shell
+helm upgrade ... \
+...
+--set statefulset.newrelic.opsteam.endpoint="<NEW_RELIC_OTLP_ENDPOINT>" \
+--set statefulset.newrelic.opsteam.licenseKey.secretRef.name="<YOUR_EXISTING_SECRET>" \
+--set statefulset.newrelic.opsteam.licenseKey.secretRef.key="<KEY_TO_LICENSE_KEY_WITHIN_THE_SECRET>" \
+...
+```
+
+**Create a new secret**
+
+If you haven't defined any secret for your license key and want to create it from scratch, you can
+
+1. Define in `values.yaml`
+
+```yaml
+newrelic:
+  opsteam:
+    endpoint: "<NEW_RELIC_OTLP_ENDPOINT>"
+    licenseKey:
+      value: "<YOUR_EXISTING_SECRET>"
+```
+
+2. Set per `helm --set`
+
+```shell
+helm upgrade ... \
+...
+--set statefulset.newrelic.opsteam.endpoint="<NEW_RELIC_OTLP_ENDPOINT>" \
+--set statefulset.newrelic.opsteam.licenseKey.value="<NEW_RELIC_LICENSE_KEY>" \
+...
+```
+
 ## Monitoring
 
 An example [monitoring](/monitoring/terraform/) is already prepared for you which you can deploy with Terraform to your New Relic account. For that, you can easily run the [`00_create_newrelic_resources.sh`](/monitoring/scripts/00_create_newrelic_resources.sh) script.

--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -58,11 +58,19 @@ spec:
   {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
     - name: {{ $teamName }}-endpoint
       value: {{ $teamInfo.endpoint }}
+    {{- if $teamInfo.licenseKey.secretRef }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
-          name: {{ $.Values.name }}-ds
-          key: {{ $teamName }}
+          name: {{ $teamInfo.licenseKey.secretRef.name }}
+          key: {{ $teamInfo.licenseKey.secretRef.key }}
+    {{- else if $teamInfo.licenseKey.value }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ $.Values.name }}-ds-{{ $teamName }}
+          key: licenseKey
+    {{- end }}
   {{- end }}
 
   # Otel configuration

--- a/helm/charts/collectors/templates/daemonset-secret.yaml
+++ b/helm/charts/collectors/templates/daemonset-secret.yaml
@@ -1,11 +1,13 @@
 {{- if eq .Values.logs.enabled true -}}
+{{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+{{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.name }}-ds
-  namespace: {{ .Release.Namespace }}
+  name: {{ $.Values.name }}-ds-{{ $teamName }}
+  namespace: {{ $.Release.Namespace }}
 data:
-{{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
-  {{ $teamName }}: {{ $teamInfo.licenseKey | b64enc }}
+  licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/charts/collectors/templates/deployment-otelcollector-exporter.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-exporter.yaml
@@ -40,11 +40,19 @@ spec:
   {{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
     - name: {{ $teamName }}-endpoint
       value: {{ $teamInfo.endpoint }}
+    {{- if $teamInfo.licenseKey.secretRef }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
-          name: {{ $.Values.name }}-dep
-          key: {{ $teamName }}
+          name: {{ $teamInfo.licenseKey.secretRef.name }}
+          key: {{ $teamInfo.licenseKey.secretRef.key }}
+    {{- else if $teamInfo.licenseKey.value }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ $.Values.name }}-dep-{{ $teamName }}
+          key: licenseKey
+    {{- end }}
   {{- end }}
 
   # Otel configuration

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -41,11 +41,19 @@ spec:
   {{- if eq $teamName "opsteam" }}
     - name: {{ $teamName }}-endpoint
       value: {{ $teamInfo.endpoint }}
+    {{- if $teamInfo.licenseKey.secretRef }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
-          name: {{ $.Values.name }}-sts
-          key: {{ $teamName }}
+          name: {{ $teamInfo.licenseKey.secretRef.name }}
+          key: {{ $teamInfo.licenseKey.secretRef.key }}
+    {{- else if $teamInfo.licenseKey.value }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ $.Values.name }}-dep-{{ $teamName }}
+          key: licenseKey
+    {{- end }}
   {{- end }}
   {{- end }}
 

--- a/helm/charts/collectors/templates/deployment-secret.yaml
+++ b/helm/charts/collectors/templates/deployment-secret.yaml
@@ -1,11 +1,13 @@
 {{- if eq .Values.traces.enabled true -}}
+{{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
+{{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.name }}-dep
-  namespace: {{ .Release.Namespace }}
+  name: {{ $.Values.name }}-dep-{{ $teamName }}
+  namespace: {{ $.Release.Namespace }}
 data:
-{{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
-  {{ $teamName }}: {{ $teamInfo.licenseKey | b64enc }}
+  licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -50,11 +50,19 @@ spec:
   {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
     - name: {{ $teamName }}-endpoint
       value: {{ $teamInfo.endpoint }}
+    {{- if $teamInfo.licenseKey.secretRef }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
-          name: {{ $.Values.name }}-sts
-          key: {{ $teamName }}
+          name: {{ $teamInfo.licenseKey.secretRef.name }}
+          key: {{ $teamInfo.licenseKey.secretRef.key }}
+    {{- else if $teamInfo.licenseKey.value }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ $.Values.name }}-sts-{{ $teamName }}
+          key: licenseKey
+    {{- end }}
   {{- end }}
 
   # Otel configuration

--- a/helm/charts/collectors/templates/statefulset-secret.yaml
+++ b/helm/charts/collectors/templates/statefulset-secret.yaml
@@ -1,11 +1,13 @@
 {{- if eq .Values.metrics.enabled true -}}
+{{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+{{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.name }}-sts
-  namespace: {{ .Release.Namespace }}
+  name: {{ $.Values.name }}-sts-{{ $teamName }}
+  namespace: {{ $.Release.Namespace }}
 data:
-{{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
-  {{ $teamName }}: {{ $teamInfo.licenseKey | b64enc }}
+  licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -97,8 +97,23 @@ deployment:
     # OPS team which is responsible for the cluster and common apps
     # running on it.
     opsteam:
+      # OTLP endpoint
+      # For US accounts -> otlp.nr-data.net:4317
+      # For EU accounts -> otlp.eu01.nr-data.net:4317
       endpoint: "otlp.nr-data.net:4317"
-      licenseKey: ""
+      # New Relic ingest license key
+      # -> Use either "value" or "secretRef" where "secretRef" will precede if both are defined
+      licenseKey:
+        # If you want to create a new secret, provide to the license key as a Helm value.
+        value: ""
+        # If you already have your license key as a secret stored within the same
+        # namespace as this Helm deployment, provide the secret name and the key to
+        # license key.
+        secretRef: null
+          # name: ""
+          # key: ""
+      # Namespaces to filter the gathered metrics
+      # -> If nothing is defined, all metrics will be sent
       namespaces: []
 
     # # If you want to send the namespaced telemetry data from the
@@ -108,14 +123,16 @@ deployment:
     # # in a specific namespace.
     # devteam1:
     #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey: ""
+    #   licenseKey:
+    #     value: ""
     #   namespaces:
     #     - devteam1
     # # Dev team 2 which is responsible for its own apps running
     # # in a specific namespace.
     # devteam2:
     #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey: ""
+    #   licenseKey:
+    #     value: ""
     #   namespaces:
     #     - devteam2
 
@@ -184,8 +201,23 @@ daemonset:
     # OPS team which is responsible for the cluster and common apps
     # running on it.
     opsteam:
+      # OTLP endpoint
+      # For US accounts -> otlp.nr-data.net:4317
+      # For EU accounts -> otlp.eu01.nr-data.net:4317
       endpoint: "otlp.nr-data.net:4317"
-      licenseKey: ""
+      # New Relic ingest license key
+      # -> Use either "value" or "secretRef" where "secretRef" will precede if both are defined
+      licenseKey:
+        # If you want to create a new secret, provide to the license key as a Helm value.
+        value: ""
+        # If you already have your license key as a secret stored within the same
+        # namespace as this Helm deployment, provide the secret name and the key to
+        # license key.
+        secretRef: null
+          # name: ""
+          # key: ""
+      # Namespaces to filter the gathered metrics
+      # -> If nothing is defined, all metrics will be sent
       namespaces: []
 
     # # If you want to send the namespaced telemetry data from the
@@ -195,14 +227,16 @@ daemonset:
     # # in a specific namespace.
     # devteam1:
     #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey: ""
+    #   licenseKey:
+    #     value: ""
     #   namespaces:
     #     - devteam1
     # # Dev team 2 which is responsible for its own apps running
     # # in a specific namespace.
     # devteam2:
     #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey: ""
+    #   licenseKey:
+    #     value: ""
     #   namespaces:
     #     - devteam2
 
@@ -332,8 +366,23 @@ statefulset:
     # OPS team which is responsible for the cluster and common apps
     # running on it.
     opsteam:
+      # OTLP endpoint
+      # For US accounts -> otlp.nr-data.net:4317
+      # For EU accounts -> otlp.eu01.nr-data.net:4317
       endpoint: "otlp.nr-data.net:4317"
-      licenseKey: ""
+      # New Relic ingest license key
+      # -> Use either "value" or "secretRef" where "secretRef" will precede if both are defined
+      licenseKey:
+        # If you want to create a new secret, provide to the license key as a Helm value.
+        value: ""
+        # If you already have your license key as a secret stored within the same
+        # namespace as this Helm deployment, provide the secret name and the key to
+        # license key.
+        secretRef: null
+          # name: ""
+          # key: ""
+      # Namespaces to filter the gathered metrics
+      # -> If nothing is defined, all metrics will be sent
       namespaces: []
 
     # # If you want to send the namespaced telemetry data from the
@@ -343,13 +392,15 @@ statefulset:
     # # in a specific namespace.
     # devteam1:
     #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey: ""
+    #   licenseKey:
+    #     value: ""
     #   namespaces:
     #     - devteam1
     # # Dev team 2 which is responsible for its own apps running
     # # in a specific namespace.
     # devteam2:
     #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey: ""
+    #   licenseKey:
+    #     value: ""
     #   namespaces:
     #     - devteam2

--- a/helm/scripts/01_deploy_collectors.sh
+++ b/helm/scripts/01_deploy_collectors.sh
@@ -72,13 +72,13 @@ helm upgrade ${otelcollectors[name]} \
   --set traces.enabled=true \
   --set deployment.ports.prometheus.port=${otelcollectors[deploymentPrometheusPort]} \
   --set deployment.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-  --set deployment.newrelic.opsteam.licenseKey=$NEWRELIC_LICENSE_KEY \
+  --set deployment.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
   --set logs.enabled=true \
   --set daemonset.ports.prometheus.port=${otelcollectors[daemonsetPrometheusPort]} \
   --set daemonset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-  --set daemonset.newrelic.opsteam.licenseKey=$NEWRELIC_LICENSE_KEY \
+  --set deployment.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
   --set metrics.enabled=true \
   --set statefulset.ports.prometheus.port=${otelcollectors[statefulsetPrometheusPort]} \
   --set statefulset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-  --set statefulset.newrelic.opsteam.licenseKey=$NEWRELIC_LICENSE_KEY \
+  --set statefulset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
   "../charts/collectors"


### PR DESCRIPTION
## Changes

- If one wants to create the secrets for the license keys from scratch, one can set the license key directly **PER** the Helm deployment
- If one already has created secrets for the license keys, one can reference them **FOR** the Helm deployment