### PR TITLE
Improved documentation for deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,26 @@ helm upgrade ${otelcollectors[name]} \
 
 The cluster name that you define will be added as an additional attribute `k8s.cluster.name` to all of telemetry data which are collected by the collectors so that later, you can filter them out according to your various clusters.
 
-### Setting up license keys
+### Setting up OTLP endpoints & license keys
 
-There are 2 ways to set your New Relic license keys:
+If the New Relic account where you want to send the data to is
+
+- in US, use `otlp.nr-data.net:4317`
+- in EU, use `otlp.eu01.nr-data.net:4317`
+
+In the [`01_deploy_collectors.sh`](./helm/scripts/01_deploy_collectors.sh), the default value is set for EU as follows:
+
+````shell
+newrelicOtlpEndpoint="otlp.eu01.nr-data.net:4317"
+
+```shell
+helm upgrade ... \
+...
+--set daemonset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
+...
+````
+
+When it comes to defining the New Relic license keys, you have 2 ways:
 
 **Reference an existing secret**
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ How to set up the license keys properly is explained [here](#setting-up-license-
 
 Feel free to customize the [Kubernetes manifest files](./helm/charts/collectors/templates/)! You can simply add your OTLP endpoints and license keys according to your New Relic accounts and run the [`01_deploy_collectors.sh`](./helm/scripts/01_deploy_collectors.sh).
 
-The script deploys `node-exporter` and `kube-state-metrics` with the OTel collectors which are required for the monitoring (see Monitoring section below).
+The script deploys `node-exporter` and `kube-state-metrics` with the OTel collectors which are **REQUIRED** for a complete monitoring (see [Monitoring](#monitoring) section below).
 
 Moreover, you will need to define a cluster name:
 
@@ -241,4 +241,4 @@ Along with the [Terraform deployment](./monitoring/), a [data ingest](./monitori
 
 ## Monitoring
 
-An example [monitoring](/monitoring) is already prepared for you which you can deploy with Terraform to your New Relic account. For that, you can easily run the [`00_create_newrelic_resources.sh`](/monitoring/scripts/00_create_newrelic_resources.sh) script. Check out the [`README`](./monitoring/README.md)!
+An example [monitoring](/monitoring) is already prepared for you which you can deploy with Terraform to your New Relic account. For that, you can easily run the [`00_create_newrelic_resources.sh`](/monitoring/scripts/00_create_newrelic_resources.sh) script. Check out the [`README`](./monitoring/README.md) for more!

--- a/helm/scripts/00_deploy_operator.sh
+++ b/helm/scripts/00_deploy_operator.sh
@@ -15,9 +15,9 @@ oteloperator["namespace"]="monitoring"
 ###################
 
 # Add helm repos
-# helm repo add jetstack https://charts.jetstack.io
-# helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
-# helm repo update
+helm repo add jetstack https://charts.jetstack.io
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
 
 # cert-manager
 helm upgrade ${certmanager[name]} \

--- a/helm/scripts/01_deploy_collectors.sh
+++ b/helm/scripts/01_deploy_collectors.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-### Set parameters
-newrelicOtlpEndpoint="otlp.eu01.nr-data.net:4317"
-
 ### Set variables
 
 # cluster name
 clusterName="my-dope-cluster"
+
+# New Relic OTLP endpoint
+newrelicOtlpEndpoint="otlp.eu01.nr-data.net:4317"
 
 # kubestatemetrics
 declare -A kubestatemetrics

--- a/monitoring/scripts/00_create_newrelic_resources.sh
+++ b/monitoring/scripts/00_create_newrelic_resources.sh
@@ -19,11 +19,12 @@ done
 
 ### Set variables
 
+# cluster name
 clusterName="my-dope-cluster"
 
 if [[ $flagDestroy != "true" ]]; then
 
-  # Initialise Terraform
+  # Initialize Terraform
   terraform -chdir=../terraform init
 
   # Plan Terraform
@@ -42,8 +43,8 @@ else
 
   # Destroy Terraform
   terraform -chdir=../terraform destroy \
-  -var NEW_RELIC_ACCOUNT_ID=$NEWRELIC_ACCOUNT_ID \
-  -var NEW_RELIC_API_KEY=$NEWRELIC_API_KEY \
-  -var NEW_RELIC_REGION=$NEWRELIC_REGION \
-  -var cluster_name=$clusterName
+    -var NEW_RELIC_ACCOUNT_ID=$NEWRELIC_ACCOUNT_ID \
+    -var NEW_RELIC_API_KEY=$NEWRELIC_API_KEY \
+    -var NEW_RELIC_REGION=$NEWRELIC_REGION \
+    -var cluster_name=$clusterName
 fi


### PR DESCRIPTION
## Changes

- The commented out `helm` repo additions for `cert-manager` and `otel-operator` are commented back in
- Scripts are formatted and cleaned up
- How to set the OTLP endpoints per account are explained
- The reason of deploying `node-exporter` & `kube-state-metrics` is linked to the monitoring section