### PR TITLE
Refactored variables into helpers.tpl & added input validation

### DIFF
--- a/helm/charts/collectors/templates/NOTES.txt
+++ b/helm/charts/collectors/templates/NOTES.txt
@@ -1,0 +1,50 @@
+#######################################
+### Enjoy your OTel K8s experience! ###
+#######################################
+{{ if and (not .Values.traces.enabled) (not .Values.logs.enabled) (not .Values.metrics.enabled) -}}
+  {{ fail "ERROR: At least one of the following must be enabled: traces, logs & metrics!" }}
+{{- end -}}
+{{ if .Values.traces.enabled -}}
+  {{- if not .Values.deployment.newrelic -}}
+    {{ fail "ERROR [DEPLOYMENT]: You have enabled traces but haven't defined any New Relic account in the deployment section to send the data to!" }}
+  {{- end -}}
+  {{- range $teamName, $teamInfo := .Values.deployment.newrelic -}}
+    {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
+      {{ fail "ERROR [DEPLOYMENT]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.eu01.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
+    {{- end -}}
+    {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
+      {{ fail "ERROR [DEPLOYMENT]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
+    {{- end -}}
+  {{- end }}
+Traces are enabled. Deployments of OTel collectors are deployed.
+{{- end -}}
+{{ if .Values.logs.enabled -}}
+  {{- if not .Values.daemonset.newrelic -}}
+    {{ fail "ERROR [DAEMONSET]: You have enabled logs but haven't defined any New Relic account in the daemonset section to send the data to!" }}
+  {{- end -}}
+  {{- range $teamName, $teamInfo := .Values.daemonset.newrelic -}}
+    {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
+      {{ fail "ERROR [DAEMONSET]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.eu01.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
+    {{- end -}}
+    {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
+      {{ fail "ERROR [DAEMONSET]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
+    {{- end -}}
+  {{- end }}
+Logs are enabled. Daemonset of OTel collectors are deployed.
+{{- end -}}
+{{ if .Values.metrics.enabled }}
+  {{- if not .Values.statefulset.newrelic -}}
+    {{ fail "ERROR [STATEFULSET]: You have enabled metrics but haven't defined any New Relic account in the statefulset section to send the data to!" }}
+  {{- end -}}
+  {{- range $teamName, $teamInfo := .Values.statefulset.newrelic -}}
+    {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
+      {{ fail "ERROR [STATEFULSET]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.eu01.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
+    {{- end -}}
+    {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
+      {{ fail "ERROR [STATEFULSET]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
+    {{- end -}}
+  {{- end }}
+Metrics are enabled. Statefulset of OTel collectors are deployed.
+{{- end }}
+
+#######################################

--- a/helm/charts/collectors/templates/_helpers.tpl
+++ b/helm/charts/collectors/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nrotel.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Set name for deployment collectors.
+*/}}
+{{- define "nrotel.deploymentName" -}}
+{{- printf "%s-%s" (include "nrotel.name" .) "dep" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "nrotel.deploymentNameReceiver" -}}
+{{- printf "%s-%s" (include "nrotel.deploymentName" .) "rec" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "nrotel.deploymentNameExporter" -}}
+{{- printf "%s-%s" (include "nrotel.deploymentName" .) "exp" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "nrotel.headlessServiceNameExporter" -}}
+{{- printf "%s-%s.%s.%s" (include "nrotel.deploymentNameExporter" .) "-collector-headless" "{{ .Release.Namespace }}" "svc.cluster.local" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Set name for daemonset collectors.
+*/}}
+{{- define "nrotel.daemonsetName" -}}
+{{- printf "%s-%s" (include "nrotel.name" .) "ds" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Set name for statefulset collectors.
+*/}}
+{{- define "nrotel.statefulsetName" -}}
+{{- printf "%s-%s" (include "nrotel.name" .) "sts" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/charts/collectors/templates/daemonset-clusterrole.yaml
+++ b/helm/charts/collectors/templates/daemonset-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.name }}-ds
+  name: {{ include "nrotel.daemonsetName" . }}
   {{- if .Values.daemonset.clusterRole.annotations }}
   annotations:
     {{- range $key, $value := .Values.daemonset.clusterRole.annotations }}

--- a/helm/charts/collectors/templates/daemonset-clusterrolebinding.yaml
+++ b/helm/charts/collectors/templates/daemonset-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.name }}-ds
+  name: {{ include "nrotel.daemonsetName" . }}
   {{- if .Values.daemonset.clusterRoleBinding.annotations }}
   annotations:
     {{- range $key, $value := .Values.daemonset.clusterRoleBinding.annotations }}
@@ -12,9 +12,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.name }}-ds
+  name: {{ include "nrotel.daemonsetName" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-ds
+  name: {{ include "nrotel.daemonsetName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -2,7 +2,7 @@
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
-  name: {{ .Values.name }}-ds
+  name: {{ include "nrotel.daemonsetName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 
@@ -10,7 +10,7 @@ spec:
   mode: "daemonset"
 
   # Service Account
-  serviceAccount: {{ .Values.name }}-ds
+  serviceAccount: {{ include "nrotel.daemonsetName" . }}
 
   # Ports to expose per service
   ports:
@@ -77,7 +77,7 @@ spec:
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
-          name: {{ $.Values.name }}-ds-{{ $teamName }}
+          name: {{ include "nrotel.daemonsetName" $ }}-{{ $teamName }}
           key: licenseKey
     {{- end }}
   {{- end }}

--- a/helm/charts/collectors/templates/daemonset-secret.yaml
+++ b/helm/charts/collectors/templates/daemonset-secret.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $.Values.name }}-ds-{{ $teamName }}
+  name: {{ include "nrotel.daemonsetName" $ }}-{{ $teamName }}
   namespace: {{ $.Release.Namespace }}
 data:
   licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}

--- a/helm/charts/collectors/templates/daemonset-serviceaccount.yaml
+++ b/helm/charts/collectors/templates/daemonset-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-ds
+  name: {{ include "nrotel.daemonsetName" . }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.daemonset.serviceAccount.annotations }}
   annotations:

--- a/helm/charts/collectors/templates/deployment-clusterrole.yaml
+++ b/helm/charts/collectors/templates/deployment-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.name }}-dep
+  name: {{ include "nrotel.deploymentName" . }}
   {{- if .Values.deployment.clusterRole.annotations }}
   annotations:
     {{- range $key, $value := .Values.deployment.clusterRole.annotations }}

--- a/helm/charts/collectors/templates/deployment-clusterrolebinding.yaml
+++ b/helm/charts/collectors/templates/deployment-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.name }}-dep
+  name: {{ include "nrotel.deploymentName" . }}
   {{- if .Values.deployment.clusterRoleBinding.annotations }}
   annotations:
     {{- range $key, $value := .Values.deployment.clusterRoleBinding.annotations }}
@@ -12,9 +12,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.name }}-dep
+  name: {{ include "nrotel.deploymentName" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-dep
+  name: {{ include "nrotel.deploymentName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/helm/charts/collectors/templates/deployment-otelcollector-exporter.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-exporter.yaml
@@ -2,7 +2,7 @@
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
-  name: {{ .Values.name }}-dep-exp
+  name: {{ include "nrotel.deploymentNameExporter" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 
@@ -10,7 +10,7 @@ spec:
   mode: "deployment"
 
   # Service Account
-  serviceAccount: {{ .Values.name }}-dep
+  serviceAccount: {{ include "nrotel.deploymentName" . }}
 
   # Ports to expose per service
   ports:
@@ -59,7 +59,7 @@ spec:
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
-          name: {{ $.Values.name }}-dep-{{ $teamName }}
+          name: {{ include "nrotel.deploymentName" $ }}-{{ $teamName }}
           key: licenseKey
     {{- end }}
   {{- end }}

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -2,7 +2,7 @@
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
-  name: {{ .Values.name }}-dep-rec
+  name: {{ include "nrotel.deploymentNameReceiver" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 
@@ -10,7 +10,7 @@ spec:
   mode: "deployment"
 
   # Service Account
-  serviceAccount: {{ .Values.name }}-dep
+  serviceAccount: {{ include "nrotel.deploymentName" . }}
 
   # Ports to expose per service
   ports:
@@ -60,7 +60,7 @@ spec:
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
-          name: {{ $.Values.name }}-dep-{{ $teamName }}
+          name: {{ include "nrotel.deploymentName" $ }}-{{ $teamName }}
           key: licenseKey
     {{- end }}
   {{- end }}
@@ -148,7 +148,7 @@ spec:
               insecure: true
         resolver:
           dns:
-            hostname: "{{ .Values.name }}-dep-exp-collector-headless.{{ .Release.Namespace }}.svc.cluster.local"
+            hostname: "{{ include "nrotel.headlessServiceNameExporter" . }}"
       otlp/opsteam:
         endpoint: ${opsteam-endpoint}
         tls:

--- a/helm/charts/collectors/templates/deployment-secret.yaml
+++ b/helm/charts/collectors/templates/deployment-secret.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $.Values.name }}-dep-{{ $teamName }}
+  name: {{ include "nrotel.deploymentName" $ }}-{{ $teamName }}
   namespace: {{ $.Release.Namespace }}
 data:
   licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}

--- a/helm/charts/collectors/templates/deployment-serviceaccount.yaml
+++ b/helm/charts/collectors/templates/deployment-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-dep
+  name: {{ include "nrotel.deploymentName" . }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.deployment.serviceAccount.annotations }}
   annotations:

--- a/helm/charts/collectors/templates/statefulset-clusterrole.yaml
+++ b/helm/charts/collectors/templates/statefulset-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.name }}-sts
+  name: {{ include "nrotel.statefulsetName" . }}
   {{- if .Values.statefulset.clusterRole.annotations }}
   annotations:
     {{- range $key, $value := .Values.statefulset.clusterRole.annotations }}

--- a/helm/charts/collectors/templates/statefulset-clusterrolebinding.yaml
+++ b/helm/charts/collectors/templates/statefulset-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.name }}-sts
+  name: {{ include "nrotel.statefulsetName" . }}
   {{- if .Values.statefulset.clusterRoleBinding.annotations }}
   annotations:
     {{- range $key, $value := .Values.statefulset.clusterRoleBinding.annotations }}
@@ -12,9 +12,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.name }}-sts
+  name: {{ include "nrotel.statefulsetName" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.name }}-sts
+  name: {{ include "nrotel.statefulsetName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -2,7 +2,7 @@
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
-  name: {{ .Values.name }}-sts
+  name: {{ include "nrotel.statefulsetName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 
@@ -13,12 +13,12 @@ spec:
   replicas: 2
 
   # Service Account
-  serviceAccount: {{ .Values.name }}-sts
+  serviceAccount: {{ include "nrotel.statefulsetName" . }}
 
   # Target allocator
   targetAllocator:
     enabled: true
-    serviceAccount: {{ .Values.name }}-sts
+    serviceAccount: {{ include "nrotel.statefulsetName" . }}
     prometheusCR:
       enabled: false
 
@@ -69,7 +69,7 @@ spec:
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
-          name: {{ $.Values.name }}-sts-{{ $teamName }}
+          name: {{ include "nrotel.statefulsetName" $ }}-{{ $teamName }}
           key: licenseKey
     {{- end }}
   {{- end }}

--- a/helm/charts/collectors/templates/statefulset-secret.yaml
+++ b/helm/charts/collectors/templates/statefulset-secret.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $.Values.name }}-sts-{{ $teamName }}
+  name: {{ include "nrotel.statefulsetName" $ }}-{{ $teamName }}
   namespace: {{ $.Release.Namespace }}
 data:
   licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}

--- a/helm/charts/collectors/templates/statefulset-serviceaccount.yaml
+++ b/helm/charts/collectors/templates/statefulset-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.name }}-sts
+  name: {{ include "nrotel.statefulsetName" . }}
   namespace: {{ .Release.Namespace }}
   {{- if .Values.statefulset.serviceAccount.annotations }}
   annotations:

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -1,7 +1,7 @@
 ### Variables
 
-# Name
-name: "nr-otel"
+# Override name
+nameOverride: null
 
 # Cluster name
 clusterName: "my-dope-cluster"


### PR DESCRIPTION
## Changes

- Collector names are centrally defined in `helpers.tpl` with necessary string length truncation
- Validation checks are implemented in `NOTES.txt`
   - At least one of the following should be enabled: `traces`, `logs` or `metrics`
   - If `traces` are enabled, `deployment` section must be provided
   - If `logs` are enabled, `daemonset` section must be provided
   - If `metrics` are enabled, `statefulset` section must be provided
   - Each New Relic account information should be valid
      - OTLP endpoint can either be `otlp.nr-data.net:4317` or `otlp.eu01.nr-data.net:4317`
      - Either license key value should be provided or a secret to license key should be referenced