### PR TITLE
Added export of metrics per OTLP receiver

### DIFF
--- a/helm/charts/collectors/templates/_helpers.tpl
+++ b/helm/charts/collectors/templates/_helpers.tpl
@@ -18,7 +18,7 @@ Set name for deployment collectors.
 {{- printf "%s-%s" (include "nrotel.deploymentName" .) "exp" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- define "nrotel.headlessServiceNameExporter" -}}
-{{- printf "%s-%s.%s.%s" (include "nrotel.deploymentNameExporter" .) "-collector-headless" "{{ .Release.Namespace }}" "svc.cluster.local" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s.%s.%s" (include "nrotel.deploymentNameExporter" .) "collector-headless" .Release.Namespace "svc.cluster.local" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -179,6 +179,18 @@ spec:
           exporters:
             - otlp/opsteam
             # - logging
+        metrics:
+          receivers:
+            - otlp
+          processors:
+            - cumulativetodelta
+            - k8sattributes
+            - attributes
+            - memory_limiter
+            - batch
+          exporters:
+            - otlp/opsteam
+            # - logging
         traces:
           receivers:
             - otlp


### PR DESCRIPTION
## Changes

- Incorrect deployment service name creation in `helpers.tpl` is fixed
- Metrics received per `otlpreceiver` are being exported to New Relic