### PR TITLE
Implement node-exporter & kube-state-metrics as helm dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 tfplan
+
+# Helm chart dependencies
+*/charts/*/charts

--- a/helm/charts/collectors/Chart.lock
+++ b/helm/charts/collectors/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: prometheus-node-exporter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 4.17.4
+- name: kube-state-metrics
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 5.7.0
+digest: sha256:2cd4f118af677190257f69e7dff003f8f28ad8899801a426acade77dfd18ef2d
+generated: "2023-06-06T13:38:08.221089+02:00"

--- a/helm/charts/collectors/Chart.yaml
+++ b/helm/charts/collectors/Chart.yaml
@@ -22,3 +22,13 @@ version: 0.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.76.1"
+
+dependencies:
+  - name: prometheus-node-exporter
+    version: 4.17.4
+    repository: https://prometheus-community.github.io/helm-charts
+    condition: statefulset.prometheus.nodeExporter.serviceNameRef
+  - name: kube-state-metrics
+    version: 5.7.0
+    repository: https://prometheus-community.github.io/helm-charts
+    condition: statefulset.prometheus.kubeStateMetrics.serviceNameRef

--- a/helm/charts/collectors/Chart.yaml
+++ b/helm/charts/collectors/Chart.yaml
@@ -27,8 +27,8 @@ dependencies:
   - name: prometheus-node-exporter
     version: 4.17.4
     repository: https://prometheus-community.github.io/helm-charts
-    condition: statefulset.prometheus.nodeExporter.serviceNameRef
+    condition: statefulset.prometheus.nodeExporter.enabled
   - name: kube-state-metrics
     version: 5.7.0
     repository: https://prometheus-community.github.io/helm-charts
-    condition: statefulset.prometheus.kubeStateMetrics.serviceNameRef
+    condition: statefulset.prometheus.kubeStateMetrics.enabled

--- a/helm/charts/collectors/templates/_helpers.tpl
+++ b/helm/charts/collectors/templates/_helpers.tpl
@@ -34,3 +34,25 @@ Set name for statefulset collectors.
 {{- define "nrotel.statefulsetName" -}}
 {{- printf "%s-%s" (include "nrotel.name" .) "sts" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Set name for node-exporter service discovery.
+*/}}
+{{- define "nrotel.nodeExporterServiceName" -}}
+{{- if .Values.statefulset.prometheus.nodeExporter.serviceNameRef -}}
+{{- printf "%s" .Values.statefulset.prometheus.nodeExporter.serviceNameRef | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" (include "nrotel.name" .) "prometheus-node-exporter" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set name for kube-state-metrics service discovery.
+*/}}
+{{- define "nrotel.kubeStateMetricsServiceName" -}}
+{{- if .Values.statefulset.prometheus.kubeStateMetrics.serviceNameRef -}}
+{{- printf "%s" .Values.statefulset.prometheus.kubeStateMetrics.serviceNameRef | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" (include "nrotel.name" .) "kube-state-metrics" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -262,7 +262,7 @@ spec:
                   replacement: $$1:$$2
                 - source_labels: [__meta_kubernetes_service_name]
                   action: keep
-                  regex: {{ .Values.statefulset.prometheus.nodeExporterServiceName }}
+                  regex: {{ include "nrotel.nodeExporterServiceName" . }}
                 - source_labels: [__meta_kubernetes_namespace]
                   action: replace
                   target_label: namespace
@@ -313,7 +313,7 @@ spec:
                   replacement: $$1:$$2
                 - source_labels: [__meta_kubernetes_service_name]
                   action: keep
-                  regex: {{ .Values.statefulset.prometheus.kubeStateMetricsServiceName }}
+                  regex: {{ include "nrotel.kubeStateMetricsServiceName" . }}
                 - source_labels: [__meta_kubernetes_namespace]
                   action: replace
                   target_label: namespace
@@ -367,10 +367,10 @@ spec:
                   regex: kube-dns
                 - source_labels: [__meta_kubernetes_service_name]
                   action: drop
-                  regex: {{ .Values.statefulset.prometheus.nodeExporterServiceName }}
+                  regex: {{ include "nrotel.nodeExporterServiceName" . }}
                 - source_labels: [__meta_kubernetes_service_name]
                   action: drop
-                  regex: {{ .Values.statefulset.prometheus.kubeStateMetricsServiceName }}
+                  regex: {{ include "nrotel.kubeStateMetricsServiceName" . }}
                 - source_labels: [__meta_kubernetes_namespace]
                   action: replace
                   target_label: namespace

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -381,10 +381,20 @@ statefulset:
     lowDataMode: false
     # Keeps only the most important metrics and drops the rest of the scraped metrics
     importantMetricsOnly: false
-    # Node exporter service name
-    nodeExporterServiceName: nodeexporter-node-exporter
-    # Kube state metrics service name
-    kubeStateMetricsServiceName: kubestatemetrics-kube-state-metrics
+    # Node exporter specific configuration
+    nodeExporter:
+      # If you already have a node-exporter on your cluster, you can give its service name as a reference
+      # to the "serviceNameRef" field. The collector will scrape that service particularly.
+      # If you don't have any node-exporter, you can let this chart deploy it as a dependency by setting
+      # the field "serviceNameRef" to null. You can override its values in the DEPENDENCY CONFIG section of this file.
+      serviceNameRef: null
+    # Kube state metrics specific configuration
+    kubeStateMetrics:
+      # If you already have a kube-state-metrics on your cluster, you can give its service name as a reference
+      # to the "serviceNameRef" field. The collector will scrape that service particularly.
+      # If you don't have any kube-state-metrics, you can let this chart deploy it as a dependency by setting
+      # the field "serviceNameRef" to null. You can override its values in the DEPENDENCY CONFIG section of this file.
+      serviceNameRef: null
 
   # New Relic account configuration
   newrelic:
@@ -429,3 +439,23 @@ statefulset:
     #     value: ""
     #   namespaces:
     #     - devteam2
+
+### DEPENDENCY CONFIG ###
+# You can override default values for the dependency helm charts in this section
+
+# Node exporter
+prometheus-node-exporter:
+  # Tolerations override
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+
+# Kube state metrics
+kube-state-metrics:
+  # Auto-sharding for horizontal scalibility
+  autosharding:
+    enabled: true

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -383,17 +383,21 @@ statefulset:
     importantMetricsOnly: false
     # Node exporter specific configuration
     nodeExporter:
-      # If you already have a node-exporter on your cluster, you can give its service name as a reference
-      # to the "serviceNameRef" field. The collector will scrape that service particularly.
-      # If you don't have any node-exporter, you can let this chart deploy it as a dependency by setting
-      # the field "serviceNameRef" to null. You can override its values in the DEPENDENCY CONFIG section of this file.
+      # - If you don't have any node-exporter, you can let this chart deploy it as a dependency by setting
+      #   the field "enabled" to true. You can override its values in the DEPENDENCY CONFIG section of this file.
+      # - If you already have a node-exporter on your cluster, you can set the field "enabled" to false and give
+      #   its service name as a reference to the field "serviceNameRef". The collector will scrape that service and
+      #   will not deploy any node-exporter.
+      enabled: true
       serviceNameRef: null
     # Kube state metrics specific configuration
     kubeStateMetrics:
-      # If you already have a kube-state-metrics on your cluster, you can give its service name as a reference
-      # to the "serviceNameRef" field. The collector will scrape that service particularly.
-      # If you don't have any kube-state-metrics, you can let this chart deploy it as a dependency by setting
-      # the field "serviceNameRef" to null. You can override its values in the DEPENDENCY CONFIG section of this file.
+      # - If you don't have any kube-state-metrics, you can let this chart deploy it as a dependency by setting
+      #   the field "enabled" to true. You can override its values in the DEPENDENCY CONFIG section of this file.
+      # - If you already have a kube-state-metrics on your cluster, you can set the field "enabled" to false and give
+      #   its service name as a reference to the field "serviceNameRef". The collector will scrape that service and
+      #   will not deploy any kube-state-metrics.
+      enabled: true
       serviceNameRef: null
 
   # New Relic account configuration

--- a/helm/scripts/01_deploy_collectors.sh
+++ b/helm/scripts/01_deploy_collectors.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# Get commandline arguments
+while (( "$#" )); do
+  case "$1" in
+    --external)
+      externalNodeExporterAndKubeStateMetrics="true"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
 ### Set variables
 
 # cluster name
@@ -8,15 +21,17 @@ clusterName="my-dope-cluster"
 # New Relic OTLP endpoint
 newrelicOtlpEndpoint="otlp.eu01.nr-data.net:4317"
 
-# kubestatemetrics
-declare -A kubestatemetrics
-kubestatemetrics["name"]="kubestatemetrics"
-kubestatemetrics["namespace"]="monitoring"
-
 # nodeexporter
 declare -A nodeexporter
 nodeexporter["name"]="nodeexporter"
+nodeexporter["remoteChartName"]="prometheus-node-exporter"
 nodeexporter["namespace"]="monitoring"
+
+# kubestatemetrics
+declare -A kubestatemetrics
+kubestatemetrics["name"]="kubestatemetrics"
+kubestatemetrics["remoteChartName"]="kube-state-metrics"
+kubestatemetrics["namespace"]="monitoring"
 
 # otelcollectors
 declare -A otelcollectors
@@ -31,55 +46,87 @@ otelcollectors["statefulsetPrometheusPort"]=8888
 ###################
 
 # Repositories
-helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 
-# nodeexporter
-helm upgrade ${nodeexporter[name]} \
-  --install \
-  --wait \
-  --debug \
-  --create-namespace \
-  --namespace ${nodeexporter[namespace]} \
-  --set tolerations[0].key="node-role.kubernetes.io/master" \
-  --set tolerations[0].operator="Exists" \
-  --set tolerations[0].effect="NoSchedule" \
-  --set tolerations[1].key="node-role.kubernetes.io/control-plane" \
-  --set tolerations[1].operator="Exists" \
-  --set tolerations[1].effect="NoSchedule" \
-  "bitnami/node-exporter"
+# If the flag for "external" is set, deploy the node-exporter and
+# kube-state-metrics separately from the actual chart and reference
+# their services.
+if [[ $externalNodeExporterAndKubeStateMetrics == "true" ]]; then
+  # nodeexporter
+  helm upgrade ${nodeexporter[name]} \
+    --install \
+    --wait \
+    --debug \
+    --create-namespace \
+    --namespace ${nodeexporter[namespace]} \
+    --set tolerations[0].key="node-role.kubernetes.io/master" \
+    --set tolerations[0].operator="Exists" \
+    --set tolerations[0].effect="NoSchedule" \
+    --set tolerations[1].key="node-role.kubernetes.io/control-plane" \
+    --set tolerations[1].operator="Exists" \
+    --set tolerations[1].effect="NoSchedule" \
+    "prometheus-community/${nodeexporter[remoteChartName]}"
 
-# kubestatemetrics
-helm upgrade ${kubestatemetrics[name]} \
-  --install \
-  --wait \
-  --debug \
-  --create-namespace \
-  --namespace ${kubestatemetrics[namespace]} \
-  --set autosharding.enabled=true \
-  "prometheus-community/kube-state-metrics"
+  # kubestatemetrics
+  helm upgrade ${kubestatemetrics[name]} \
+    --install \
+    --wait \
+    --debug \
+    --create-namespace \
+    --namespace ${kubestatemetrics[namespace]} \
+    --set autosharding.enabled=true \
+    "prometheus-community/${kubestatemetrics[remoteChartName]}"
 
-# otelcollector
-helm upgrade ${otelcollectors[name]} \
-  --install \
-  --wait \
-  --debug \
-  --create-namespace \
-  --namespace ${otelcollectors[namespace]} \
-  --set clusterName=$clusterName \
-  --set traces.enabled=true \
-  --set deployment.ports.prometheus.port=${otelcollectors[deploymentPrometheusPort]} \
-  --set deployment.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-  --set deployment.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
-  --set logs.enabled=true \
-  --set daemonset.ports.prometheus.port=${otelcollectors[daemonsetPrometheusPort]} \
-  --set daemonset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-  --set daemonset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
-  --set metrics.enabled=true \
-  --set statefulset.ports.prometheus.port=${otelcollectors[statefulsetPrometheusPort]} \
-  --set statefulset.prometheus.nodeExporterServiceName="${nodeexporter[name]}-node-exporter" \
-  --set statefulset.prometheus.kubeStateMetricsServiceName="${kubestatemetrics[name]}-kube-state-metrics" \
-  --set statefulset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-  --set statefulset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
-  "../charts/collectors"
+  # otelcollector
+  helm upgrade ${otelcollectors[name]} \
+    --install \
+    --wait \
+    --debug \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set traces.enabled=true \
+    --set deployment.ports.prometheus.port=${otelcollectors[deploymentPrometheusPort]} \
+    --set deployment.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set deployment.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    --set logs.enabled=true \
+    --set daemonset.ports.prometheus.port=${otelcollectors[daemonsetPrometheusPort]} \
+    --set daemonset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set daemonset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    --set metrics.enabled=true \
+    --set statefulset.ports.prometheus.port=${otelcollectors[statefulsetPrometheusPort]} \
+    --set statefulset.prometheus.nodeExporter.enabled=false \
+    --set statefulset.prometheus.nodeExporter.serviceNameRef="${nodeexporter[name]}-${nodeexporter[remoteChartName]}" \
+    --set statefulset.prometheus.kubeStateMetrics.enabled=false \
+    --set statefulset.prometheus.kubeStateMetrics.serviceNameRef="${kubestatemetrics[name]}-${kubestatemetrics[remoteChartName]}" \
+    --set statefulset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set statefulset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    "../charts/collectors"
+
+# If the flag "external" is not set, deploy the node-exporter and
+# the kube-state-metrics with the actual chart as dependencies.
+else
+  # otelcollector
+  helm dependency build "../charts/collectors"
+  helm upgrade ${otelcollectors[name]} \
+    --install \
+    --wait \
+    --debug \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set traces.enabled=true \
+    --set deployment.ports.prometheus.port=${otelcollectors[deploymentPrometheusPort]} \
+    --set deployment.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set deployment.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    --set logs.enabled=true \
+    --set daemonset.ports.prometheus.port=${otelcollectors[daemonsetPrometheusPort]} \
+    --set daemonset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set daemonset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    --set metrics.enabled=true \
+    --set statefulset.ports.prometheus.port=${otelcollectors[statefulsetPrometheusPort]} \
+    --set statefulset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set statefulset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    "../charts/collectors"
+fi


### PR DESCRIPTION
## Changes

- The `node-exporter` and `kube-state-metrics` charts are added as dependencies with fixed versions to the actual helm chart
- Necessary segragation between the chart dependent and externally provided `node-exporter` and `kube-state-metrics` is implemented into the `values.yaml`