### PR TITLE
Added global account export config

### DIFF
--- a/.github/workflows/validate_helm_input.yml
+++ b/.github/workflows/validate_helm_input.yml
@@ -50,6 +50,24 @@ jobs:
           - name: License key should be defined - Statefulset
             id: 11
 
+          - name: Referenced license key should have a name - Deployment
+            id: 12
+
+          - name: Referenced license key should have a name - Daemonset
+            id: 13
+
+          - name: Referenced license key should have a name - Statefulset
+            id: 14
+
+          - name: Referenced license key should have a key - Deployment
+            id: 15
+
+          - name: Referenced license key should have a key - Daemonset
+            id: 16
+
+          - name: Referenced license key should have a key - Statefulset
+            id: 17
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/validate_helm_input.yml
+++ b/.github/workflows/validate_helm_input.yml
@@ -19,54 +19,62 @@ jobs:
         cases:
           - name: Cluster name should be defined
             id: 01
-
           - name: At least 1 telemetry type should be enabled
             id: 02
-
           - name: New Relic account should be defined - Deployment
             id: 03
-
           - name: New Relic account should be defined - Daemonset
             id: 04
-
           - name: New Relic account should be defined - Statefulset
             id: 05
-
-          - name: OTLP endpoint should be valid - Deployment
+          - name: OTLP endpoint should be valid (global) - Deployment
             id: 06
-
-          - name: OTLP endpoint should be valid - Daemonset
+          - name: OTLP endpoint should be valid (global) - Daemonset
             id: 07
-
-          - name: OTLP endpoint should be valid - Statefulset
+          - name: OTLP endpoint should be valid (global) - Statefulset
             id: 08
-
-          - name: License key should be defined - Deployment
+          - name: OTLP endpoint should be valid (individual) - Deployment
             id: 09
-
-          - name: License key should be defined - Daemonset
+          - name: OTLP endpoint should be valid (individual) - Daemonset
             id: 10
-
-          - name: License key should be defined - Statefulset
+          - name: OTLP endpoint should be valid (individual) - Statefulset
             id: 11
-
-          - name: Referenced license key should have a name - Deployment
+          - name: License key should be defined (global) - Deployment
             id: 12
-
-          - name: Referenced license key should have a name - Daemonset
+          - name: License key should be defined (global) - Daemonset
             id: 13
-
-          - name: Referenced license key should have a name - Statefulset
+          - name: License key should be defined (global) - Statefulset
             id: 14
-
-          - name: Referenced license key should have a key - Deployment
+          - name: License key should be defined (individual) - Deployment
             id: 15
-
-          - name: Referenced license key should have a key - Daemonset
+          - name: License key should be defined (individual) - Daemonset
             id: 16
-
-          - name: Referenced license key should have a key - Statefulset
+          - name: License key should be defined (individual) - Statefulset
             id: 17
+          - name: Referenced license key should have a name (global) - Deployment
+            id: 18
+          - name: Referenced license key should have a name (global) - Daemonset
+            id: 19
+          - name: Referenced license key should have a name (global) - Statefulset
+            id: 20
+          - name: Referenced license key should have a name (individual) - Deployment
+            id: 21
+          - name: Referenced license key should have a name (individual) - Daemonset
+            id: 22
+          - name: Referenced license key should have a name (individual) - Statefulset
+            id: 23
+          - name: Referenced license key should have a key (global) - Deployment
+            id: 24
+          - name: Referenced license key should have a key (global) - Daemonset
+            id: 25
+          - name: Referenced license key should have a key (global) - Statefulset
+            id: 26
+          - name: Referenced license key should have a key (individual) - Deployment
+            id: 27
+          - name: Referenced license key should have a key (individual) - Daemonset
+            id: 28
+          - name: Referenced license key should have a key (individual) - Statefulset
+            id: 29
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -62,29 +62,63 @@ If you were to have 1 ops team & 2 dev teams and would like to send the telemetr
 you can use the following configuration for daemonset, deployment and statefulset:
 
 ```yaml
-opsteam:
-  endpoint: "OTLP_ENDPOINT_OPS_TEAM"
-  licenseKey:
-    value: "LICENSE_KEY_OPS_TEAM"
-  namespaces: []
-devteam1:
-  endpoint: "OTLP_ENDPOINT_DEV_TEAM_1"
-  licenseKey:
-    value: "LICENSE_KEY_DEV_TEAM_1"
-  namespaces:
-    - namespace_of_dev_team_1
-devteam2:
-  endpoint: "OTLP_ENDPOINT_DEV_TEAM_2"
-  licenseKey:
-    value: "LICENSE_KEY_DEV_TEAM_2"
-  namespaces:
-    - namespace_of_dev_team_2
+statefulset: # also deployment or daemonset
+  newrelic:
+    teams:
+      opsteam:
+        endpoint: "OTLP_ENDPOINT_OPS_TEAM"
+        licenseKey:
+          value: "LICENSE_KEY_OPS_TEAM"
+        namespaces: []
+      devteam1:
+        endpoint: "OTLP_ENDPOINT_DEV_TEAM_1"
+        licenseKey:
+          value: "LICENSE_KEY_DEV_TEAM_1"
+        namespaces:
+          - namespace-devteam-1
+      devteam2:
+        endpoint: "OTLP_ENDPOINT_DEV_TEAM_2"
+        licenseKey:
+          value: "LICENSE_KEY_DEV_TEAM_2"
+        namespaces:
+          - namespace-devteam-2
 ```
 
 Since all of the telemetry data is centrally collected by 3 variations of collectors, each variation can filter the data according to the namespaces where the data is coming from. So centrally gathered data will be
 
 - filtered by multiple processors depending on the config above
 - routed to corresponding exporters and thereby to corresponding New Relic accounts
+
+The configuration above is the default way of setting up individual accounts to export the telemetry data.
+
+If,
+
+- all of your New Relic accounts are in the same New Relic datacenter (US or EU)
+- the individual teams are to be given only the telemetry data which belong to their namespaces
+
+you can simplify the deployment per the global configuration as follows:
+
+```yaml
+global:
+  enabled: true
+  endpoint: "OTLP_ENDPOINT_FOR_ALL_ACCOUNTS"
+  newrelic:
+    teams:
+      opsteam:
+        licenseKey:
+          value: "LICENSE_KEY_OPS_TEAM"
+        namespaces: []
+      devteam1:
+        licenseKey:
+          value: "LICENSE_KEY_DEV_TEAM_1"
+        namespaces:
+          - namespace-devteam-1
+      devteam2:
+        licenseKey:
+          value: "LICENSE_KEY_DEV_TEAM_2"
+        namespaces:
+          - namespace-devteam-2
+```
 
 How to set up the license keys properly is explained [here](#setting-up-license-keys).
 
@@ -127,7 +161,7 @@ newrelicOtlpEndpoint="otlp.eu01.nr-data.net:4317"
 ```shell
 helm upgrade ... \
 ...
---set daemonset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
+--set daemonset.newrelic.teams.opsteam.endpoint=$newrelicOtlpEndpoint \
 ...
 ````
 
@@ -141,12 +175,13 @@ If you already have put your secrets into a Kubernetes secret within the same na
 
 ```yaml
 newrelic:
-  opsteam:
-    endpoint: "<NEW_RELIC_OTLP_ENDPOINT>"
-    licenseKey:
-      secretRef:
-        name: "<YOUR_EXISTING_SECRET>"
-        key: "<KEY_TO_LICENSE_KEY_WITHIN_THE_SECRET>"
+  teams:
+    opsteam:
+      endpoint: "<NEW_RELIC_OTLP_ENDPOINT>"
+      licenseKey:
+        secretRef:
+          name: "<YOUR_EXISTING_SECRET>"
+          key: "<KEY_TO_LICENSE_KEY_WITHIN_THE_SECRET>"
 ```
 
 2. Set per `helm --set`
@@ -154,9 +189,9 @@ newrelic:
 ```shell
 helm upgrade ... \
 ...
---set statefulset.newrelic.opsteam.endpoint="<NEW_RELIC_OTLP_ENDPOINT>" \
---set statefulset.newrelic.opsteam.licenseKey.secretRef.name="<YOUR_EXISTING_SECRET>" \
---set statefulset.newrelic.opsteam.licenseKey.secretRef.key="<KEY_TO_LICENSE_KEY_WITHIN_THE_SECRET>" \
+--set statefulset.newrelic.teams.opsteam.endpoint="<NEW_RELIC_OTLP_ENDPOINT>" \
+--set statefulset.newrelic.teams.opsteam.licenseKey.secretRef.name="<YOUR_EXISTING_SECRET>" \
+--set statefulset.newrelic.teams.opsteam.licenseKey.secretRef.key="<KEY_TO_LICENSE_KEY_WITHIN_THE_SECRET>" \
 ...
 ```
 
@@ -168,10 +203,11 @@ If you haven't defined any secret for your license key and want to create it fro
 
 ```yaml
 newrelic:
-  opsteam:
-    endpoint: "<NEW_RELIC_OTLP_ENDPOINT>"
-    licenseKey:
-      value: "<YOUR_EXISTING_SECRET>"
+  teams:
+    opsteam:
+      endpoint: "<NEW_RELIC_OTLP_ENDPOINT>"
+      licenseKey:
+        value: "<YOUR_EXISTING_SECRET>"
 ```
 
 2. Set per `helm --set`
@@ -179,8 +215,8 @@ newrelic:
 ```shell
 helm upgrade ... \
 ...
---set statefulset.newrelic.opsteam.endpoint="<NEW_RELIC_OTLP_ENDPOINT>" \
---set statefulset.newrelic.opsteam.licenseKey.value="<NEW_RELIC_LICENSE_KEY>" \
+--set statefulset.newrelic.teams.opsteam.endpoint="<NEW_RELIC_OTLP_ENDPOINT>" \
+--set statefulset.newrelic.teams.opsteam.licenseKey.value="<NEW_RELIC_LICENSE_KEY>" \
 ...
 ```
 

--- a/helm/charts/collectors/templates/NOTES.txt
+++ b/helm/charts/collectors/templates/NOTES.txt
@@ -8,68 +8,125 @@
   {{ fail "ERROR: Cluster name should be defined!" }}
 {{- end -}}
 {{ if .Values.traces.enabled -}}
-  {{- if not .Values.deployment.newrelic -}}
-    {{ fail "ERROR [DEPLOYMENT]: You have enabled traces but haven't defined any New Relic account in the deployment section to send the data to!" }}
+  {{- if and (not .Values.global.newrelic.enabled) (not .Values.deployment.newrelic) -}}
+    {{ fail "ERROR [DEPLOYMENT]: You have enabled traces but haven't defined any New Relic account neither in the global section nor in the deployment section to send the data to!" }}
   {{- end -}}
-  {{- range $teamName, $teamInfo := .Values.deployment.newrelic -}}
-    {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
-      {{ fail "ERROR [DEPLOYMENT]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
+  {{- if .Values.global.newrelic.enabled -}}
+    {{- if and (ne .Values.global.newrelic.endpoint "otlp.nr-data.net:4317") (ne .Values.global.newrelic.endpoint "otlp.eu01.nr-data.net:4317") -}}
+      {{ fail "ERROR [DEPLOYMENT]: The given global OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
     {{- end -}}
-    {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
-      {{ fail "ERROR [DEPLOYMENT]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
-    {{- end -}}
-    {{- if $teamInfo.licenseKey.secretRef }}
-      {{- if (not $teamInfo.licenseKey.secretRef.name) }}
-        {{ fail "ERROR [DEPLOYMENT]: License key is referenced but its name is not provided!" }}
+    {{- range $teamName, $teamInfo := .Values.global.newrelic.teams -}}
+      {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
+        {{ fail "ERROR [DEPLOYMENT]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
       {{- end -}}
-      {{- if (not $teamInfo.licenseKey.secretRef.key) }}
-        {{ fail "ERROR [DEPLOYMENT]: License key is referenced but the key to the license key within the secret is not provided!" }}
+      {{- if $teamInfo.licenseKey.secretRef }}
+        {{- if (not $teamInfo.licenseKey.secretRef.name) }}
+          {{ fail "ERROR [DEPLOYMENT]: License key is referenced but its name is not provided!" }}
+        {{- end -}}
+        {{- if (not $teamInfo.licenseKey.secretRef.key) }}
+          {{ fail "ERROR [DEPLOYMENT]: License key is referenced but the key to the license key within the secret is not provided!" }}
+        {{- end -}}
       {{- end -}}
-    {{- end -}}
+    {{- end }}
+  {{- else -}}
+    {{- range $teamName, $teamInfo := .Values.deployment.newrelic -}}
+      {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
+        {{ fail "ERROR [DEPLOYMENT]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
+      {{- end -}}
+      {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
+        {{ fail "ERROR [DEPLOYMENT]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
+      {{- end -}}
+      {{- if $teamInfo.licenseKey.secretRef }}
+        {{- if (not $teamInfo.licenseKey.secretRef.name) }}
+          {{ fail "ERROR [DEPLOYMENT]: License key is referenced but its name is not provided!" }}
+        {{- end -}}
+        {{- if (not $teamInfo.licenseKey.secretRef.key) }}
+          {{ fail "ERROR [DEPLOYMENT]: License key is referenced but the key to the license key within the secret is not provided!" }}
+        {{- end -}}
+      {{- end -}}
+    {{- end }}
   {{- end }}
 Traces are enabled. Deployments of OTel collectors are deployed.
 {{- end -}}
 {{ if .Values.logs.enabled -}}
-  {{- if not .Values.daemonset.newrelic -}}
-    {{ fail "ERROR [DAEMONSET]: You have enabled logs but haven't defined any New Relic account in the daemonset section to send the data to!" }}
+  {{- if and (not .Values.global.newrelic.enabled) (not .Values.daemonset.newrelic) -}}
+    {{ fail "ERROR [DAEMONSET]: You have enabled logs but haven't defined any New Relic account neither in the global section nor in the daemonset section to send the data to!" }}
   {{- end -}}
-  {{- range $teamName, $teamInfo := .Values.daemonset.newrelic -}}
-    {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
-      {{ fail "ERROR [DAEMONSET]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
+  {{- if .Values.global.newrelic.enabled -}}
+    {{- if and (ne .Values.global.newrelic.endpoint "otlp.nr-data.net:4317") (ne .Values.global.newrelic.endpoint "otlp.eu01.nr-data.net:4317") -}}
+      {{ fail "ERROR [DAEMONSET]: The given global OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
     {{- end -}}
-    {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
-      {{ fail "ERROR [DAEMONSET]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
-    {{- end -}}
-    {{- if $teamInfo.licenseKey.secretRef }}
-      {{- if (not $teamInfo.licenseKey.secretRef.name) }}
-        {{ fail "ERROR [DAEMONSET]: License key is referenced but its name is not provided!" }}
+    {{- range $teamName, $teamInfo := .Values.global.newrelic.teams -}}
+      {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
+        {{ fail "ERROR [DAEMONSET]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
       {{- end -}}
-      {{- if (not $teamInfo.licenseKey.secretRef.key) }}
-        {{ fail "ERROR [DAEMONSET]: License key is referenced but the key to the license key within the secret is not provided!" }}
+      {{- if $teamInfo.licenseKey.secretRef }}
+        {{- if (not $teamInfo.licenseKey.secretRef.name) }}
+          {{ fail "ERROR [DAEMONSET]: License key is referenced but its name is not provided!" }}
+        {{- end -}}
+        {{- if (not $teamInfo.licenseKey.secretRef.key) }}
+          {{ fail "ERROR [DAEMONSET]: License key is referenced but the key to the license key within the secret is not provided!" }}
+        {{- end -}}
       {{- end -}}
-    {{- end -}}
+    {{- end }}
+  {{- else -}}
+    {{- range $teamName, $teamInfo := .Values.daemonset.newrelic -}}
+      {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
+        {{ fail "ERROR [DAEMONSET]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
+      {{- end -}}
+      {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
+        {{ fail "ERROR [DAEMONSET]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
+      {{- end -}}
+      {{- if $teamInfo.licenseKey.secretRef }}
+        {{- if (not $teamInfo.licenseKey.secretRef.name) }}
+          {{ fail "ERROR [DAEMONSET]: License key is referenced but its name is not provided!" }}
+        {{- end -}}
+        {{- if (not $teamInfo.licenseKey.secretRef.key) }}
+          {{ fail "ERROR [DAEMONSET]: License key is referenced but the key to the license key within the secret is not provided!" }}
+        {{- end -}}
+      {{- end -}}
+    {{- end }}
   {{- end }}
 Logs are enabled. Daemonset of OTel collectors are deployed.
 {{- end -}}
 {{ if .Values.metrics.enabled }}
-  {{- if not .Values.statefulset.newrelic -}}
-    {{ fail "ERROR [STATEFULSET]: You have enabled metrics but haven't defined any New Relic account in the statefulset section to send the data to!" }}
+  {{- if and (not .Values.global.newrelic.enabled) (not .Values.statefulset.newrelic) -}}
+    {{ fail "ERROR [STATEFULSET]: You have enabled metrics but haven't defined any New Relic account neither in the global section nor in the statefulet section to send the data to!" }}
   {{- end -}}
-  {{- range $teamName, $teamInfo := .Values.statefulset.newrelic -}}
-    {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
-      {{ fail "ERROR [STATEFULSET]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
+  {{- if .Values.global.newrelic.enabled -}}
+    {{- if and (ne .Values.global.newrelic.endpoint "otlp.nr-data.net:4317") (ne .Values.global.newrelic.endpoint "otlp.eu01.nr-data.net:4317") -}}
+      {{ fail "ERROR [STATEFULSET]: The given global OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
     {{- end -}}
-    {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
-      {{ fail "ERROR [STATEFULSET]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
-    {{- end -}}
-    {{- if $teamInfo.licenseKey.secretRef }}
-      {{- if (not $teamInfo.licenseKey.secretRef.name) }}
-        {{ fail "ERROR [STATEFULSET]: License key is referenced but its name is not provided!" }}
+    {{- range $teamName, $teamInfo := .Values.global.newrelic.teams -}}
+      {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
+        {{ fail "ERROR [STATEFULSET]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
       {{- end -}}
-      {{- if (not $teamInfo.licenseKey.secretRef.key) }}
-        {{ fail "ERROR [STATEFULSET]: License key is referenced but the key to the license key within the secret is not provided!" }}
+      {{- if $teamInfo.licenseKey.secretRef }}
+        {{- if (not $teamInfo.licenseKey.secretRef.name) }}
+          {{ fail "ERROR [STATEFULSET]: License key is referenced but its name is not provided!" }}
+        {{- end -}}
+        {{- if (not $teamInfo.licenseKey.secretRef.key) }}
+          {{ fail "ERROR [STATEFULSET]: License key is referenced but the key to the license key within the secret is not provided!" }}
+        {{- end -}}
       {{- end -}}
-    {{- end -}}
+    {{- end }}
+  {{- else -}}
+    {{- range $teamName, $teamInfo := .Values.statefulset.newrelic -}}
+      {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
+        {{ fail "ERROR [STATEFULSET]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
+      {{- end -}}
+      {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
+        {{ fail "ERROR [STATEFULSET]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
+      {{- end -}}
+      {{- if $teamInfo.licenseKey.secretRef }}
+        {{- if (not $teamInfo.licenseKey.secretRef.name) }}
+          {{ fail "ERROR [STATEFULSET]: License key is referenced but its name is not provided!" }}
+        {{- end -}}
+        {{- if (not $teamInfo.licenseKey.secretRef.key) }}
+          {{ fail "ERROR [STATEFULSET]: License key is referenced but the key to the license key within the secret is not provided!" }}
+        {{- end -}}
+      {{- end -}}
+    {{- end }}
   {{- end }}
 Metrics are enabled. Statefulset of OTel collectors are deployed.
 {{- end }}

--- a/helm/charts/collectors/templates/NOTES.txt
+++ b/helm/charts/collectors/templates/NOTES.txt
@@ -29,7 +29,7 @@
       {{- end -}}
     {{- end }}
   {{- else -}}
-    {{- range $teamName, $teamInfo := .Values.deployment.newrelic -}}
+    {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams -}}
       {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
         {{ fail "ERROR [DEPLOYMENT]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
       {{- end -}}
@@ -70,7 +70,7 @@ Traces are enabled. Deployments of OTel collectors are deployed.
       {{- end -}}
     {{- end }}
   {{- else -}}
-    {{- range $teamName, $teamInfo := .Values.daemonset.newrelic -}}
+    {{- range $teamName, $teamInfo := .Values.daemonset.newrelic.teams -}}
       {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
         {{ fail "ERROR [DAEMONSET]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
       {{- end -}}
@@ -111,7 +111,7 @@ Logs are enabled. Daemonset of OTel collectors are deployed.
       {{- end -}}
     {{- end }}
   {{- else -}}
-    {{- range $teamName, $teamInfo := .Values.statefulset.newrelic -}}
+    {{- range $teamName, $teamInfo := .Values.statefulset.newrelic.teams -}}
       {{- if and (ne $teamInfo.endpoint "otlp.nr-data.net:4317") (ne $teamInfo.endpoint "otlp.eu01.nr-data.net:4317") -}}
         {{ fail "ERROR [STATEFULSET]: The given OTLP enpoint is incorrect. Valid values: For US -> otlp.nr-data.net:4317 or for EU -> otlp.eu01.nr-data.net:4317" }}
       {{- end -}}

--- a/helm/charts/collectors/templates/NOTES.txt
+++ b/helm/charts/collectors/templates/NOTES.txt
@@ -18,6 +18,14 @@
     {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
       {{ fail "ERROR [DEPLOYMENT]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
     {{- end -}}
+    {{- if $teamInfo.licenseKey.secretRef }}
+      {{- if (not $teamInfo.licenseKey.secretRef.name) }}
+        {{ fail "ERROR [DEPLOYMENT]: License key is referenced but its name is not provided!" }}
+      {{- end -}}
+      {{- if (not $teamInfo.licenseKey.secretRef.key) }}
+        {{ fail "ERROR [DEPLOYMENT]: License key is referenced but the key to the license key within the secret is not provided!" }}
+      {{- end -}}
+    {{- end -}}
   {{- end }}
 Traces are enabled. Deployments of OTel collectors are deployed.
 {{- end -}}
@@ -32,6 +40,14 @@ Traces are enabled. Deployments of OTel collectors are deployed.
     {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
       {{ fail "ERROR [DAEMONSET]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
     {{- end -}}
+    {{- if $teamInfo.licenseKey.secretRef }}
+      {{- if (not $teamInfo.licenseKey.secretRef.name) }}
+        {{ fail "ERROR [DAEMONSET]: License key is referenced but its name is not provided!" }}
+      {{- end -}}
+      {{- if (not $teamInfo.licenseKey.secretRef.key) }}
+        {{ fail "ERROR [DAEMONSET]: License key is referenced but the key to the license key within the secret is not provided!" }}
+      {{- end -}}
+    {{- end -}}
   {{- end }}
 Logs are enabled. Daemonset of OTel collectors are deployed.
 {{- end -}}
@@ -45,6 +61,14 @@ Logs are enabled. Daemonset of OTel collectors are deployed.
     {{- end -}}
     {{- if and (not $teamInfo.licenseKey.secretRef) (not $teamInfo.licenseKey.value) }}
       {{ fail "ERROR [STATEFULSET]: Neither a license key secret is referenced nor the value of the license key is provided!" }}
+    {{- end -}}
+    {{- if $teamInfo.licenseKey.secretRef }}
+      {{- if (not $teamInfo.licenseKey.secretRef.name) }}
+        {{ fail "ERROR [STATEFULSET]: License key is referenced but its name is not provided!" }}
+      {{- end -}}
+      {{- if (not $teamInfo.licenseKey.secretRef.key) }}
+        {{ fail "ERROR [STATEFULSET]: License key is referenced but the key to the license key within the secret is not provided!" }}
+      {{- end -}}
     {{- end -}}
   {{- end }}
 Metrics are enabled. Statefulset of OTel collectors are deployed.

--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -83,7 +83,7 @@ spec:
       {{- end }}
     {{- end }}
   {{- else }}
-    {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+    {{- range $teamName, $teamInfo := .Values.daemonset.newrelic.teams }}
     - name: {{ $teamName }}-endpoint
       value: {{ $teamInfo.endpoint }}
       {{- if $teamInfo.licenseKey.secretRef }}
@@ -244,7 +244,7 @@ spec:
           {{- end }}
         {{- end }}
       {{- else }}
-        {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+        {{- range $teamName, $teamInfo := .Values.daemonset.newrelic.teams }}
           {{- if ne (len $teamInfo.namespaces) 0 }}
       filter/{{ $teamName }}:
         error_mode: ignore
@@ -272,13 +272,24 @@ spec:
         send_batch_size : 800
 
     exporters:
-    {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+    {{- if .Values.global.newrelic.enabled }}
+      {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
       otlp/{{ $teamName }}:
         endpoint: ${env:{{ $teamName }}-endpoint}
         tls:
           insecure: false
         headers:
           api-key: ${env:{{ $teamName }}-licenseKey}
+      {{- end }}
+    {{- else }}
+      {{- range $teamName, $teamInfo := .Values.daemonset.newrelic.teams }}
+      otlp/{{ $teamName }}:
+        endpoint: ${env:{{ $teamName }}-endpoint}
+        tls:
+          insecure: false
+        headers:
+          api-key: ${env:{{ $teamName }}-licenseKey}
+      {{- end }}
     {{- end }}
       logging:
         verbosity: detailed
@@ -322,7 +333,7 @@ spec:
             # - logging
         {{- end }}
       {{- else }}
-        {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+        {{- range $teamName, $teamInfo := .Values.daemonset.newrelic.teams }}
         logs/{{ $teamName }}:
           receivers:
             - filelog

--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -253,9 +253,9 @@ spec:
           {{ $conditionForK8sNamespaceName := "" -}}
           {{- range $index, $namespace := $teamInfo.namespaces -}}
             {{- if eq $index 0 -}}
-              {{- $conditionForK8sNamespaceName = printf "attributes[\"k8s.namespace.name\"] != \"%s\"" $namespace -}}
+              {{- $conditionForK8sNamespaceName = printf "resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $namespace -}}
             {{ else }}
-              {{- $conditionForK8sNamespaceName = printf "%s and attributes[\"k8s.namespace.name\"] != \"%s\"" $conditionForK8sNamespaceName $namespace -}}
+              {{- $conditionForK8sNamespaceName = printf "%s and resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $conditionForK8sNamespaceName $namespace -}}
             {{- end -}}
           {{- end -}}
             - '{{ $conditionForK8sNamespaceName }}'

--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -64,21 +64,41 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-  {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+  {{- if .Values.global.newrelic.enabled }}
+    {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
     - name: {{ $teamName }}-endpoint
-      value: {{ $teamInfo.endpoint }}
-    {{- if $teamInfo.licenseKey.secretRef }}
+      value: {{ $.Values.global.newrelic.endpoint }}
+      {{- if $teamInfo.licenseKey.secretRef }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
           name: {{ $teamInfo.licenseKey.secretRef.name }}
           key: {{ $teamInfo.licenseKey.secretRef.key }}
-    {{- else if $teamInfo.licenseKey.value }}
+      {{- else if $teamInfo.licenseKey.value }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
           name: {{ include "nrotel.daemonsetName" $ }}-{{ $teamName }}
           key: licenseKey
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+    - name: {{ $teamName }}-endpoint
+      value: {{ $teamInfo.endpoint }}
+      {{- if $teamInfo.licenseKey.secretRef }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ $teamInfo.licenseKey.secretRef.name }}
+          key: {{ $teamInfo.licenseKey.secretRef.key }}
+      {{- else if $teamInfo.licenseKey.value }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "nrotel.daemonsetName" $ }}-{{ $teamName }}
+          key: licenseKey
+      {{- end }}
     {{- end }}
   {{- end }}
 
@@ -205,25 +225,42 @@ spec:
           - key: k8s.pod.name
             value: $MY_POD_NAME
             action: upsert
-      {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
-      {{- if ne (len $teamInfo.namespaces) 0 }}
+      {{- if .Values.global.newrelic.enabled }}
+        {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
+          {{- if ne (len $teamInfo.namespaces) 0 }}
       filter/{{ $teamName }}:
         error_mode: ignore
         logs:
           log_record:
-          {{ $condition := "IsMatch(attributes[\"k8s.namespace.name\"], " -}}
+          {{ $conditionForK8sNamespaceName := "" -}}
           {{- range $index, $namespace := $teamInfo.namespaces -}}
             {{- if eq $index 0 -}}
-              {{- $condition = printf "%s\"%s" $condition $namespace -}}
+              {{- $conditionForK8sNamespaceName = printf "resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $namespace -}}
             {{ else }}
-              {{- $condition = printf "%s|%s" $condition $namespace -}}
-            {{- end -}}
-            {{- if eq $index (sub (len $teamInfo.namespaces) 1) -}}
-              {{- $condition = printf "%s\") == true" $condition -}}
+              {{- $conditionForK8sNamespaceName = printf "%s and resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $conditionForK8sNamespaceName $namespace -}}
             {{- end -}}
           {{- end -}}
-            - '{{ $condition }}'
-      {{- end }}
+            - '{{ $conditionForK8sNamespaceName }}'
+          {{- end }}
+        {{- end }}
+      {{- else }}
+        {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+          {{- if ne (len $teamInfo.namespaces) 0 }}
+      filter/{{ $teamName }}:
+        error_mode: ignore
+        logs:
+          log_record:
+          {{ $conditionForK8sNamespaceName := "" -}}
+          {{- range $index, $namespace := $teamInfo.namespaces -}}
+            {{- if eq $index 0 -}}
+              {{- $conditionForK8sNamespaceName = printf "attributes[\"k8s.namespace.name\"] != \"%s\"" $namespace -}}
+            {{ else }}
+              {{- $conditionForK8sNamespaceName = printf "%s and attributes[\"k8s.namespace.name\"] != \"%s\"" $conditionForK8sNamespaceName $namespace -}}
+            {{- end -}}
+          {{- end -}}
+            - '{{ $conditionForK8sNamespaceName }}'
+          {{- end }}
+        {{- end }}
       {{- end }}
       memory_limiter:
          check_interval: 1s
@@ -267,7 +304,8 @@ spec:
           exporters:
             - otlp/opsteam
             # - logging
-      {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+      {{- if .Values.global.newrelic.enabled }}
+        {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
         logs/{{ $teamName }}:
           receivers:
             - filelog
@@ -282,6 +320,24 @@ spec:
           exporters:
             - otlp/{{ $teamName }}
             # - logging
+        {{- end }}
+      {{- else }}
+        {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+        logs/{{ $teamName }}:
+          receivers:
+            - filelog
+          processors:
+            - k8sattributes
+            - attributes
+            - memory_limiter
+          {{- if ne (len $teamInfo.namespaces) 0 }}
+            - filter/{{ $teamName }}
+          {{- end }}
+            - batch
+          exporters:
+            - otlp/{{ $teamName }}
+            # - logging
+        {{- end }}
       {{- end }}
       telemetry:
         # logs:

--- a/helm/charts/collectors/templates/daemonset-secret.yaml
+++ b/helm/charts/collectors/templates/daemonset-secret.yaml
@@ -13,7 +13,7 @@ data:
       {{- end -}}
     {{- end -}}
   {{- else -}}
-      {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+      {{- range $teamName, $teamInfo := .Values.daemonset.newrelic.teams }}
         {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret

--- a/helm/charts/collectors/templates/daemonset-secret.yaml
+++ b/helm/charts/collectors/templates/daemonset-secret.yaml
@@ -1,6 +1,7 @@
 {{- if eq .Values.logs.enabled true -}}
-{{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
-{{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
+  {{- if .Values.global.newrelic.enabled -}}
+    {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
+      {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +10,20 @@ metadata:
 data:
   licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}
 ---
-{{- end -}}
-{{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+      {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+        {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nrotel.daemonsetName" $ }}-{{ $teamName }}
+  namespace: {{ $.Release.Namespace }}
+data:
+  licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}
+---
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}

--- a/helm/charts/collectors/templates/deployment-otelcollector-exporter.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-exporter.yaml
@@ -46,7 +46,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-  {{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
+  {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
     - name: {{ $teamName }}-endpoint
       value: {{ $teamInfo.endpoint }}
     {{- if $teamInfo.licenseKey.secretRef }}
@@ -129,7 +129,7 @@ spec:
           - key: k8s.pod.name
             value: $MY_POD_NAME
             action: upsert
-      {{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
+      {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
       {{- if ne (len $teamInfo.namespaces) 0 }}
       filter/{{ $teamName }}:
         error_mode: ignore
@@ -150,7 +150,7 @@ spec:
         send_batch_size : 800
 
     exporters:
-    {{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
+    {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
       otlp/{{ $teamName }}:
         endpoint: ${env:{{ $teamName }}-endpoint}
         tls:
@@ -182,7 +182,7 @@ spec:
           exporters:
             - otlp/opsteam
             # - logging
-      {{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
+      {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
         traces/{{ $teamName }}:
           receivers:
             - otlp

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.logs.enabled true -}}
+{{- if eq .Values.traces.enabled true -}}
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
@@ -46,7 +46,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-  {{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
+  {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
   {{- if eq $teamName "opsteam" }}
     - name: {{ $teamName }}-endpoint
       value: {{ $teamInfo.endpoint }}

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -46,7 +46,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-  {{- range $teamName, $teamInfo := .Values.daemonset.newrelic }}
+  {{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
   {{- if eq $teamName "opsteam" }}
     - name: {{ $teamName }}-endpoint
       value: {{ $teamInfo.endpoint }}

--- a/helm/charts/collectors/templates/deployment-secret.yaml
+++ b/helm/charts/collectors/templates/deployment-secret.yaml
@@ -13,7 +13,7 @@ data:
       {{- end -}}
     {{- end -}}
   {{- else -}}
-    {{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
+    {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
       {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret

--- a/helm/charts/collectors/templates/deployment-secret.yaml
+++ b/helm/charts/collectors/templates/deployment-secret.yaml
@@ -1,6 +1,7 @@
 {{- if eq .Values.traces.enabled true -}}
-{{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
-{{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
+  {{- if .Values.global.newrelic.enabled -}}
+    {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
+      {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +10,20 @@ metadata:
 data:
   licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}
 ---
-{{- end -}}
-{{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- range $teamName, $teamInfo := .Values.deployment.newrelic }}
+      {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nrotel.deploymentName" $ }}-{{ $teamName }}
+  namespace: {{ $.Release.Namespace }}
+data:
+  licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}
+---
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -75,7 +75,7 @@ spec:
       {{- end }}
     {{- end }}
   {{- else }}
-    {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+    {{- range $teamName, $teamInfo := .Values.statefulset.newrelic.teams }}
     - name: {{ $teamName }}-endpoint
       value: {{ $teamInfo.endpoint }}
       {{- if $teamInfo.licenseKey.secretRef }}
@@ -465,7 +465,7 @@ spec:
           {{- end }}
         {{- end }}
       {{- else }}
-        {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+        {{- range $teamName, $teamInfo := .Values.statefulset.newrelic.teams }}
           {{- if ne (len $teamInfo.namespaces) 0 }}
       filter/{{ $teamName }}:
         error_mode: ignore
@@ -501,13 +501,24 @@ spec:
         send_batch_size : 800
 
     exporters:
-    {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+    {{- if .Values.global.newrelic.enabled }}
+      {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
       otlp/{{ $teamName }}:
         endpoint: ${env:{{ $teamName }}-endpoint}
         tls:
           insecure: false
         headers:
           api-key: ${env:{{ $teamName }}-licenseKey}
+      {{- end }}
+    {{- else }}
+      {{- range $teamName, $teamInfo := .Values.statefulset.newrelic.teams }}
+      otlp/{{ $teamName }}:
+        endpoint: ${env:{{ $teamName }}-endpoint}
+        tls:
+          insecure: false
+        headers:
+          api-key: ${env:{{ $teamName }}-licenseKey}
+      {{- end }}
     {{- end }}
       logging:
         # verbosity: detailed
@@ -552,7 +563,7 @@ spec:
             # - logging
         {{- end }}
       {{- else }}
-        {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+        {{- range $teamName, $teamInfo := .Values.statefulset.newrelic.teams }}
         metrics/{{ $teamName }}:
           receivers:
             - prometheus

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -56,21 +56,41 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-  {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+  {{- if .Values.global.newrelic.enabled }}
+    {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
     - name: {{ $teamName }}-endpoint
-      value: {{ $teamInfo.endpoint }}
-    {{- if $teamInfo.licenseKey.secretRef }}
+      value: {{ $.Values.global.newrelic.endpoint }}
+      {{- if $teamInfo.licenseKey.secretRef }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
           name: {{ $teamInfo.licenseKey.secretRef.name }}
           key: {{ $teamInfo.licenseKey.secretRef.key }}
-    {{- else if $teamInfo.licenseKey.value }}
+      {{- else if $teamInfo.licenseKey.value }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
           name: {{ include "nrotel.statefulsetName" $ }}-{{ $teamName }}
           key: licenseKey
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+    - name: {{ $teamName }}-endpoint
+      value: {{ $teamInfo.endpoint }}
+      {{- if $teamInfo.licenseKey.secretRef }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ $teamInfo.licenseKey.secretRef.name }}
+          key: {{ $teamInfo.licenseKey.secretRef.key }}
+      {{- else if $teamInfo.licenseKey.value }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "nrotel.statefulsetName" $ }}-{{ $teamName }}
+          key: licenseKey
+      {{- end }}
     {{- end }}
   {{- end }}
 
@@ -418,8 +438,9 @@ spec:
           - key: k8s.pod.name
             value: $MY_POD_NAME
             action: upsert
-      {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
-      {{- if ne (len $teamInfo.namespaces) 0 }}
+      {{- if .Values.global.newrelic.enabled }}
+        {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
+          {{- if ne (len $teamInfo.namespaces) 0 }}
       filter/{{ $teamName }}:
         error_mode: ignore
         metrics:
@@ -441,7 +462,34 @@ spec:
             {{- end -}}
           {{- end -}}
             - '(resource.attributes["service.name"] != "kubernetes-nodes-cadvisor" or ({{ $conditionForNamespace }})) and (resource.attributes["service.name"] != "kubernetes-kube-state-metrics" or ({{ $conditionForNamespace }})) and (resource.attributes["service.name"] != "kubernetes-service-endpoints" or ({{ $conditionForK8sNamespaceName }}))'
-      {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- else }}
+        {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+          {{- if ne (len $teamInfo.namespaces) 0 }}
+      filter/{{ $teamName }}:
+        error_mode: ignore
+        metrics:
+          datapoint:
+          {{ $conditionForNamespace := "" -}}
+          {{- range $index, $namespace := $teamInfo.namespaces -}}
+            {{- if eq $index 0 -}}
+              {{- $conditionForNamespace = printf "attributes[\"namespace\"] != \"%s\"" $namespace -}}
+            {{ else }}
+              {{- $conditionForNamespace = printf "%s and attributes[\"namespace\"] != \"%s\"" $conditionForNamespace $namespace -}}
+            {{- end -}}
+          {{- end -}}
+          {{ $conditionForK8sNamespaceName := "" -}}
+          {{- range $index, $namespace := $teamInfo.namespaces -}}
+            {{- if eq $index 0 -}}
+              {{- $conditionForK8sNamespaceName = printf "resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $namespace -}}
+            {{ else }}
+              {{- $conditionForK8sNamespaceName = printf "%s and resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $conditionForK8sNamespaceName $namespace -}}
+            {{- end -}}
+          {{- end -}}
+            - '(resource.attributes["service.name"] != "kubernetes-nodes-cadvisor" or ({{ $conditionForNamespace }})) and (resource.attributes["service.name"] != "kubernetes-kube-state-metrics" or ({{ $conditionForNamespace }})) and (resource.attributes["service.name"] != "kubernetes-service-endpoints" or ({{ $conditionForK8sNamespaceName }}))'
+          {{- end }}
+        {{- end }}
       {{- end }}
       memory_limiter:
          check_interval: 1s
@@ -485,7 +533,8 @@ spec:
           exporters:
             - otlp/opsteam
             # - logging
-      {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+      {{- if .Values.global.newrelic.enabled }}
+        {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
         metrics/{{ $teamName }}:
           receivers:
             - prometheus
@@ -501,6 +550,25 @@ spec:
           exporters:
             - otlp/{{ $teamName }}
             # - logging
+        {{- end }}
+      {{- else }}
+        {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+        metrics/{{ $teamName }}:
+          receivers:
+            - prometheus
+          processors:
+            - cumulativetodelta
+            - k8sattributes
+            - attributes
+            - memory_limiter
+          {{- if ne (len $teamInfo.namespaces) 0 }}
+            - filter/{{ $teamName }}
+          {{- end }}
+            - batch
+          exporters:
+            - otlp/{{ $teamName }}
+            # - logging
+        {{- end }}
       {{- end }}
       telemetry:
         # logs:

--- a/helm/charts/collectors/templates/statefulset-secret.yaml
+++ b/helm/charts/collectors/templates/statefulset-secret.yaml
@@ -1,6 +1,7 @@
 {{- if eq .Values.metrics.enabled true -}}
-{{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
-{{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
+  {{- if .Values.global.newrelic.enabled -}}
+    {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
+      {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +10,20 @@ metadata:
 data:
   licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}
 ---
-{{- end -}}
-{{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+      {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nrotel.statefulsetName" $ }}-{{ $teamName }}
+  namespace: {{ $.Release.Namespace }}
+data:
+  licenseKey: {{ $teamInfo.licenseKey.value | b64enc }}
+---
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}

--- a/helm/charts/collectors/templates/statefulset-secret.yaml
+++ b/helm/charts/collectors/templates/statefulset-secret.yaml
@@ -13,7 +13,7 @@ data:
       {{- end -}}
     {{- end -}}
   {{- else -}}
-    {{- range $teamName, $teamInfo := .Values.statefulset.newrelic }}
+    {{- range $teamName, $teamInfo := .Values.statefulset.newrelic.teams }}
       {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -17,6 +17,58 @@ traces:
 metrics:
   enabled: true
 
+### GLOBAL CONFIG ###
+# Global config for ease of use to apply to all collector types.
+global:
+
+  # New Relic account configuration
+  newrelic:
+    # Flag to enable global New Relic configuration.
+    # -> If it is enabled, the individual New Relic sections for deployment, daemonset
+    #    and statefulset will be ignored
+    enabled: false
+    # OTLP endpoint for all New Relic accounts
+    # For US accounts -> otlp.nr-data.net:4317
+    # For EU accounts -> otlp.eu01.nr-data.net:4317
+    endpoint: "otlp.nr-data.net:4317"
+    # Teams to segragete the telemetry data received by all of the collectors.
+    teams:
+      # OPS team which is responsible for the cluster and common apps
+      # running on it.
+      opsteam:
+        # New Relic ingest license key
+        # -> Use either "value" or "secretRef" where "secretRef" will precede if both are defined
+        licenseKey:
+          # If you want to create a new secret, provide to the license key as a Helm value.
+          value: ""
+          # If you already have your license key as a secret stored within the same
+          # namespace as this Helm deployment, provide the secret name and the key to
+          # license key.
+          secretRef: null
+            # name: ""
+            # key: ""
+        # Namespaces to filter the gathered telemetry data
+        # -> If nothing is defined, all telemetry data will be sent
+        namespaces: []
+
+      # # If you want to send the namespaced telemetry data from the
+      # # cluster to the accounts of the individual dev teams
+      # # comment in below.
+      # # Dev team 1 which is responsible for its own apps running
+      # # in a specific namespace.
+      # devteam1:
+      #   licenseKey:
+      #     value: ""
+      #   namespaces:
+      #     - devteam1
+      # # Dev team 2 which is responsible for its own apps running
+      # # in a specific namespace.
+      # devteam2:
+      #   licenseKey:
+      #     value: ""
+      #   namespaces:
+      #     - devteam2
+
 ### DEPLOYMENT CONFIG ###
 # This configuration creates 2 collectors as Kubernetes deployments:
 # - receiver
@@ -100,6 +152,7 @@ deployment:
     importantMetricsOnly: false
 
   # New Relic account configuration
+  # -> If the global New Relic configuration is enabled, this section will be ignored
   newrelic:
     # OPS team which is responsible for the cluster and common apps
     # running on it.
@@ -211,6 +264,7 @@ daemonset:
     importantMetricsOnly: false
 
   # New Relic account configuration
+  # -> If the global New Relic configuration is enabled, this section will be ignored
   newrelic:
     # OPS team which is responsible for the cluster and common apps
     # running on it.
@@ -401,6 +455,7 @@ statefulset:
       serviceNameRef: null
 
   # New Relic account configuration
+  # -> If the global New Relic configuration is enabled, this section will be ignored
   newrelic:
     # OPS team which is responsible for the cluster and common apps
     # running on it.

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -119,8 +119,8 @@ deployment:
         secretRef: null
           # name: ""
           # key: ""
-      # Namespaces to filter the gathered metrics
-      # -> If nothing is defined, all metrics will be sent
+      # Namespaces to filter the gathered telemetry data
+      # -> If nothing is defined, all telemetry data will be sent
       namespaces: []
 
     # # If you want to send the namespaced telemetry data from the
@@ -230,8 +230,8 @@ daemonset:
         secretRef: null
           # name: ""
           # key: ""
-      # Namespaces to filter the gathered metrics
-      # -> If nothing is defined, all metrics will be sent
+      # Namespaces to filter the gathered telemetry data
+      # -> If nothing is defined, all telemetry data will be sent
       namespaces: []
 
     # # If you want to send the namespaced telemetry data from the
@@ -420,8 +420,8 @@ statefulset:
         secretRef: null
           # name: ""
           # key: ""
-      # Namespaces to filter the gathered metrics
-      # -> If nothing is defined, all metrics will be sent
+      # Namespaces to filter the gathered telemetry data
+      # -> If nothing is defined, all telemetry data will be sent
       namespaces: []
 
     # # If you want to send the namespaced telemetry data from the

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -154,47 +154,49 @@ deployment:
   # New Relic account configuration
   # -> If the global New Relic configuration is enabled, this section will be ignored
   newrelic:
-    # OPS team which is responsible for the cluster and common apps
-    # running on it.
-    opsteam:
-      # OTLP endpoint
-      # For US accounts -> otlp.nr-data.net:4317
-      # For EU accounts -> otlp.eu01.nr-data.net:4317
-      endpoint: "otlp.nr-data.net:4317"
-      # New Relic ingest license key
-      # -> Use either "value" or "secretRef" where "secretRef" will precede if both are defined
-      licenseKey:
-        # If you want to create a new secret, provide to the license key as a Helm value.
-        value: ""
-        # If you already have your license key as a secret stored within the same
-        # namespace as this Helm deployment, provide the secret name and the key to
-        # license key.
-        secretRef: null
-          # name: ""
-          # key: ""
-      # Namespaces to filter the gathered telemetry data
-      # -> If nothing is defined, all telemetry data will be sent
-      namespaces: []
+    # Teams to segragete the telemetry data received by all of the collectors.
+    teams:
+      # OPS team which is responsible for the cluster and common apps
+      # running on it.
+      opsteam:
+        # OTLP endpoint
+        # For US accounts -> otlp.nr-data.net:4317
+        # For EU accounts -> otlp.eu01.nr-data.net:4317
+        endpoint: "otlp.nr-data.net:4317"
+        # New Relic ingest license key
+        # -> Use either "value" or "secretRef" where "secretRef" will precede if both are defined
+        licenseKey:
+          # If you want to create a new secret, provide to the license key as a Helm value.
+          value: ""
+          # If you already have your license key as a secret stored within the same
+          # namespace as this Helm deployment, provide the secret name and the key to
+          # license key.
+          secretRef: null
+            # name: ""
+            # key: ""
+        # Namespaces to filter the gathered telemetry data
+        # -> If nothing is defined, all telemetry data will be sent
+        namespaces: []
 
-    # # If you want to send the namespaced telemetry data from the
-    # # cluster to the accounts of the individual dev teams
-    # # comment in below.
-    # # Dev team 1 which is responsible for its own apps running
-    # # in a specific namespace.
-    # devteam1:
-    #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey:
-    #     value: ""
-    #   namespaces:
-    #     - devteam1
-    # # Dev team 2 which is responsible for its own apps running
-    # # in a specific namespace.
-    # devteam2:
-    #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey:
-    #     value: ""
-    #   namespaces:
-    #     - devteam2
+      # # If you want to send the namespaced telemetry data from the
+      # # cluster to the accounts of the individual dev teams
+      # # comment in below.
+      # # Dev team 1 which is responsible for its own apps running
+      # # in a specific namespace.
+      # devteam1:
+      #   endpoint: "otlp.nr-data.net:4317"
+      #   licenseKey:
+      #     value: ""
+      #   namespaces:
+      #     - devteam1
+      # # Dev team 2 which is responsible for its own apps running
+      # # in a specific namespace.
+      # devteam2:
+      #   endpoint: "otlp.nr-data.net:4317"
+      #   licenseKey:
+      #     value: ""
+      #   namespaces:
+      #     - devteam2
 
 ### DAEMONSET CONFIG ###
 # This configuration is responsible for collecting the logs from the
@@ -266,47 +268,49 @@ daemonset:
   # New Relic account configuration
   # -> If the global New Relic configuration is enabled, this section will be ignored
   newrelic:
-    # OPS team which is responsible for the cluster and common apps
-    # running on it.
-    opsteam:
-      # OTLP endpoint
-      # For US accounts -> otlp.nr-data.net:4317
-      # For EU accounts -> otlp.eu01.nr-data.net:4317
-      endpoint: "otlp.nr-data.net:4317"
-      # New Relic ingest license key
-      # -> Use either "value" or "secretRef" where "secretRef" will precede if both are defined
-      licenseKey:
-        # If you want to create a new secret, provide to the license key as a Helm value.
-        value: ""
-        # If you already have your license key as a secret stored within the same
-        # namespace as this Helm deployment, provide the secret name and the key to
-        # license key.
-        secretRef: null
-          # name: ""
-          # key: ""
-      # Namespaces to filter the gathered telemetry data
-      # -> If nothing is defined, all telemetry data will be sent
-      namespaces: []
+    # Teams to segragete the telemetry data received by all of the collectors.
+    teams:
+      # OPS team which is responsible for the cluster and common apps
+      # running on it.
+      opsteam:
+        # OTLP endpoint
+        # For US accounts -> otlp.nr-data.net:4317
+        # For EU accounts -> otlp.eu01.nr-data.net:4317
+        endpoint: "otlp.nr-data.net:4317"
+        # New Relic ingest license key
+        # -> Use either "value" or "secretRef" where "secretRef" will precede if both are defined
+        licenseKey:
+          # If you want to create a new secret, provide to the license key as a Helm value.
+          value: ""
+          # If you already have your license key as a secret stored within the same
+          # namespace as this Helm deployment, provide the secret name and the key to
+          # license key.
+          secretRef: null
+            # name: ""
+            # key: ""
+        # Namespaces to filter the gathered telemetry data
+        # -> If nothing is defined, all telemetry data will be sent
+        namespaces: []
 
-    # # If you want to send the namespaced telemetry data from the
-    # # cluster to the accounts of the individual dev teams
-    # # comment in below.
-    # # Dev team 1 which is responsible for its own apps running
-    # # in a specific namespace.
-    # devteam1:
-    #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey:
-    #     value: ""
-    #   namespaces:
-    #     - devteam1
-    # # Dev team 2 which is responsible for its own apps running
-    # # in a specific namespace.
-    # devteam2:
-    #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey:
-    #     value: ""
-    #   namespaces:
-    #     - devteam2
+      # # If you want to send the namespaced telemetry data from the
+      # # cluster to the accounts of the individual dev teams
+      # # comment in below.
+      # # Dev team 1 which is responsible for its own apps running
+      # # in a specific namespace.
+      # devteam1:
+      #   endpoint: "otlp.nr-data.net:4317"
+      #   licenseKey:
+      #     value: ""
+      #   namespaces:
+      #     - devteam1
+      # # Dev team 2 which is responsible for its own apps running
+      # # in a specific namespace.
+      # devteam2:
+      #   endpoint: "otlp.nr-data.net:4317"
+      #   licenseKey:
+      #     value: ""
+      #   namespaces:
+      #     - devteam2
 
 ### STATEFULSET CONFIG ###
 # This configuration is responsible for scraping the metrics from the
@@ -457,47 +461,49 @@ statefulset:
   # New Relic account configuration
   # -> If the global New Relic configuration is enabled, this section will be ignored
   newrelic:
-    # OPS team which is responsible for the cluster and common apps
-    # running on it.
-    opsteam:
-      # OTLP endpoint
-      # For US accounts -> otlp.nr-data.net:4317
-      # For EU accounts -> otlp.eu01.nr-data.net:4317
-      endpoint: "otlp.nr-data.net:4317"
-      # New Relic ingest license key
-      # -> Use either "value" or "secretRef" where "secretRef" will precede if both are defined
-      licenseKey:
-        # If you want to create a new secret, provide to the license key as a Helm value.
-        value: ""
-        # If you already have your license key as a secret stored within the same
-        # namespace as this Helm deployment, provide the secret name and the key to
-        # license key.
-        secretRef: null
-          # name: ""
-          # key: ""
-      # Namespaces to filter the gathered telemetry data
-      # -> If nothing is defined, all telemetry data will be sent
-      namespaces: []
+    # Teams to segragete the telemetry data received by all of the collectors.
+    teams:
+      # OPS team which is responsible for the cluster and common apps
+      # running on it.
+      opsteam:
+        # OTLP endpoint
+        # For US accounts -> otlp.nr-data.net:4317
+        # For EU accounts -> otlp.eu01.nr-data.net:4317
+        endpoint: "otlp.nr-data.net:4317"
+        # New Relic ingest license key
+        # -> Use either "value" or "secretRef" where "secretRef" will precede if both are defined
+        licenseKey:
+          # If you want to create a new secret, provide to the license key as a Helm value.
+          value: ""
+          # If you already have your license key as a secret stored within the same
+          # namespace as this Helm deployment, provide the secret name and the key to
+          # license key.
+          secretRef: null
+            # name: ""
+            # key: ""
+        # Namespaces to filter the gathered telemetry data
+        # -> If nothing is defined, all telemetry data will be sent
+        namespaces: []
 
-    # # If you want to send the namespaced telemetry data from the
-    # # cluster to the accounts of the individual dev teams
-    # # comment in below.
-    # # Dev team 1 which is responsible for its own apps running
-    # # in a specific namespace.
-    # devteam1:
-    #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey:
-    #     value: ""
-    #   namespaces:
-    #     - devteam1
-    # # Dev team 2 which is responsible for its own apps running
-    # # in a specific namespace.
-    # devteam2:
-    #   endpoint: "otlp.nr-data.net:4317"
-    #   licenseKey:
-    #     value: ""
-    #   namespaces:
-    #     - devteam2
+      # # If you want to send the namespaced telemetry data from the
+      # # cluster to the accounts of the individual dev teams
+      # # comment in below.
+      # # Dev team 1 which is responsible for its own apps running
+      # # in a specific namespace.
+      # devteam1:
+      #   endpoint: "otlp.nr-data.net:4317"
+      #   licenseKey:
+      #     value: ""
+      #   namespaces:
+      #     - devteam1
+      # # Dev team 2 which is responsible for its own apps running
+      # # in a specific namespace.
+      # devteam2:
+      #   endpoint: "otlp.nr-data.net:4317"
+      #   licenseKey:
+      #     value: ""
+      #   namespaces:
+      #     - devteam2
 
 ### DEPENDENCY CONFIG ###
 # You can override default values for the dependency helm charts in this section

--- a/helm/scripts/01_deploy_collectors.sh
+++ b/helm/scripts/01_deploy_collectors.sh
@@ -88,20 +88,20 @@ if [[ $externalNodeExporterAndKubeStateMetrics == "true" ]]; then
     --set clusterName=$clusterName \
     --set traces.enabled=true \
     --set deployment.ports.prometheus.port=${otelcollectors[deploymentPrometheusPort]} \
-    --set deployment.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-    --set deployment.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    --set deployment.newrelic.teams.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set deployment.newrelic.teams.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
     --set logs.enabled=true \
     --set daemonset.ports.prometheus.port=${otelcollectors[daemonsetPrometheusPort]} \
-    --set daemonset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-    --set daemonset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    --set daemonset.newrelic.teams.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set daemonset.newrelic.teams.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
     --set metrics.enabled=true \
     --set statefulset.ports.prometheus.port=${otelcollectors[statefulsetPrometheusPort]} \
     --set statefulset.prometheus.nodeExporter.enabled=false \
     --set statefulset.prometheus.nodeExporter.serviceNameRef="${nodeexporter[name]}-${nodeexporter[remoteChartName]}" \
     --set statefulset.prometheus.kubeStateMetrics.enabled=false \
     --set statefulset.prometheus.kubeStateMetrics.serviceNameRef="${kubestatemetrics[name]}-${kubestatemetrics[remoteChartName]}" \
-    --set statefulset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-    --set statefulset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    --set statefulset.newrelic.teams.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set statefulset.newrelic.teams.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
     "../charts/collectors"
 
 # If the flag "external" is not set, deploy the node-exporter and
@@ -118,15 +118,15 @@ else
     --set clusterName=$clusterName \
     --set traces.enabled=true \
     --set deployment.ports.prometheus.port=${otelcollectors[deploymentPrometheusPort]} \
-    --set deployment.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-    --set deployment.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    --set deployment.newrelic.teams.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set deployment.newrelic.teams.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
     --set logs.enabled=true \
     --set daemonset.ports.prometheus.port=${otelcollectors[daemonsetPrometheusPort]} \
-    --set daemonset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-    --set daemonset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    --set daemonset.newrelic.teams.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set daemonset.newrelic.teams.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
     --set metrics.enabled=true \
     --set statefulset.ports.prometheus.port=${otelcollectors[statefulsetPrometheusPort]} \
-    --set statefulset.newrelic.opsteam.endpoint=$newrelicOtlpEndpoint \
-    --set statefulset.newrelic.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
+    --set statefulset.newrelic.teams.opsteam.endpoint=$newrelicOtlpEndpoint \
+    --set statefulset.newrelic.teams.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \
     "../charts/collectors"
 fi

--- a/helm/scripts/01_deploy_collectors.sh
+++ b/helm/scripts/01_deploy_collectors.sh
@@ -116,7 +116,7 @@ else
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
-    --set traces.enabled=true \
+    --set traces.enabled=false \
     --set deployment.ports.prometheus.port=${otelcollectors[deploymentPrometheusPort]} \
     --set deployment.newrelic.teams.opsteam.endpoint=$newrelicOtlpEndpoint \
     --set deployment.newrelic.teams.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,3 +52,23 @@ If any telemetry type is enabled, the license key of the corresponding New Relic
 | `deployment` | `09` |
 | `daemonset`  | `10` |
 | `statefulet` | `11` |
+
+### Case 12, 13, 14 - License key reference should have a name
+
+If the license key of the corresponding New Relic account is defined by referencing an existing secret which holds the license key, the name of the secret should be given.
+
+| K8s object   | Case |
+| ------------ | ---- |
+| `deployment` | `12` |
+| `daemonset`  | `13` |
+| `statefulet` | `14` |
+
+### Case 15, 16, 17 - License key reference should have a key
+
+If the license key of the corresponding New Relic account is defined by referencing an existing secret which holds the license key, the key in itself that points to the license key should be given.
+
+| K8s object   | Case |
+| ------------ | ---- |
+| `deployment` | `15` |
+| `daemonset`  | `16` |
+| `statefulet` | `17` |

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,9 +30,9 @@ If any telemetry type is enabled, it also has to have a New Relic block defined 
 | `daemonset`  | `04` |
 | `statefulet` | `05` |
 
-### Case 06, 07, 08 - OTLP endpoint should be valid
+### Case 06, 07, 08 - OTLP endpoint should be valid (global)
 
-If any telemetry type is enabled, the OTLP endpoint of the corresponding New Relic account should be valid where
+If any telemetry type and global config are enabled, the OTLP endpoint of the corresponding New Relic account should be valid where
 
 - US -> `otlp.nr-data.net:4317`
 - EU -> `otlp.eu01.nr-data.net:4317`
@@ -43,9 +43,12 @@ If any telemetry type is enabled, the OTLP endpoint of the corresponding New Rel
 | `daemonset`  | `07` |
 | `statefulet` | `08` |
 
-### Case 09, 10, 11 - License key should be defined
+### Case 09, 10, 11 - OTLP endpoint should be valid (individual)
 
-If any telemetry type is enabled, the license key of the corresponding New Relic account should either be defined directly by providing the value to the helm chart or by referencing an existing secret which holds the license key.
+If any telemetry type is enabled and individual configs are used, the OTLP endpoint of the corresponding New Relic account should be valid where
+
+- US -> `otlp.nr-data.net:4317`
+- EU -> `otlp.eu01.nr-data.net:4317`
 
 | K8s object   | Case |
 | ------------ | ---- |
@@ -53,9 +56,9 @@ If any telemetry type is enabled, the license key of the corresponding New Relic
 | `daemonset`  | `10` |
 | `statefulet` | `11` |
 
-### Case 12, 13, 14 - License key reference should have a name
+### Case 12, 13, 14 - License key should be defined (global)
 
-If the license key of the corresponding New Relic account is defined by referencing an existing secret which holds the license key, the name of the secret should be given.
+If any telemetry type and global config are enabled, the license key of the corresponding New Relic account should either be defined directly by providing the value to the helm chart or by referencing an existing secret which holds the license key.
 
 | K8s object   | Case |
 | ------------ | ---- |
@@ -63,12 +66,52 @@ If the license key of the corresponding New Relic account is defined by referenc
 | `daemonset`  | `13` |
 | `statefulet` | `14` |
 
-### Case 15, 16, 17 - License key reference should have a key
+### Case 15, 16, 17 - License key should be defined (individual)
 
-If the license key of the corresponding New Relic account is defined by referencing an existing secret which holds the license key, the key in itself that points to the license key should be given.
+If any telemetry type is enabled and individual configs are used, the license key of the corresponding New Relic account should either be defined directly by providing the value to the helm chart or by referencing an existing secret which holds the license key.
 
 | K8s object   | Case |
 | ------------ | ---- |
 | `deployment` | `15` |
 | `daemonset`  | `16` |
 | `statefulet` | `17` |
+
+### Case 18, 19, 20 - License key reference should have a name (global)
+
+If the license key of the corresponding New Relic account is defined globally by referencing an existing secret which holds the license key, the name of the secret should be given.
+
+| K8s object   | Case |
+| ------------ | ---- |
+| `deployment` | `18` |
+| `daemonset`  | `19` |
+| `statefulet` | `20` |
+
+### Case 21, 22, 23 - License key reference should have a name (individual)
+
+If the license key of the corresponding New Relic account is defined individually by referencing an existing secret which holds the license key, the name of the secret should be given.
+
+| K8s object   | Case |
+| ------------ | ---- |
+| `deployment` | `21` |
+| `daemonset`  | `22` |
+| `statefulet` | `23` |
+
+### Case 24, 25, 26 - License key reference should have a key (global)
+
+If the license key of the corresponding New Relic account is defined globally by referencing an existing secret which holds the license key, the key in itself that points to the license key should be given.
+
+| K8s object   | Case |
+| ------------ | ---- |
+| `deployment` | `24` |
+| `daemonset`  | `25` |
+| `statefulet` | `26` |
+
+### Case 27, 28, 29 - License key reference should have a key (individual)
+
+If the license key of the corresponding New Relic account is defined individually by referencing an existing secret which holds the license key, the key in itself that points to the license key should be given.
+
+| K8s object   | Case |
+| ------------ | ---- |
+| `deployment` | `27` |
+| `daemonset`  | `28` |
+| `statefulet` | `29` |

--- a/tests/scripts/01_test_helm_inputs.sh
+++ b/tests/scripts/01_test_helm_inputs.sh
@@ -133,7 +133,7 @@ if [[ $case == "08" ]]; then
     2> /dev/null)
 fi
 
-### Case 09, 10, 11 - Invalid license key
+### Case 09, 10, 11 - License key should be defined
 
 # Deployment
 if [[ $case == "09" ]]; then
@@ -177,6 +177,102 @@ if [[ $case == "11" ]]; then
     2> /dev/null)
 fi
 
+### Case 12, 13, 14 - License key reference should have a name
+
+# Deployment
+if [[ $case == "12" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set traces.enabled=true \
+    --set deployment.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set deployment.newrelic.opsteam.licenseKey.secretRef.key="key" \
+    --set logs.enabled=false \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    1> /dev/null)
+fi
+
+# Daemonset
+if [[ $case == "13" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set traces.enabled=false \
+    --set logs.enabled=true \
+    --set daemonset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set daemonset.newrelic.opsteam.licenseKey.secretRef.key="key" \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    1> /dev/null)
+fi
+
+# Statefulset
+if [[ $case == "14" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set traces.enabled=false \
+    --set logs.enabled=false \
+    --set metrics.enabled=true \
+    --set statefulset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set statefulset.newrelic.opsteam.licenseKey.secretRef.key="key" \
+    "../../helm/charts/collectors" \
+    1> /dev/null)
+fi
+
+### Case 15, 16, 17 - License key reference should have a key
+
+# Deployment
+if [[ $case == "15" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set traces.enabled=true \
+    --set deployment.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set deployment.newrelic.opsteam.licenseKey.secretRef.name="name" \
+    --set logs.enabled=false \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    1> /dev/null)
+fi
+
+# Daemonset
+if [[ $case == "16" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set traces.enabled=false \
+    --set logs.enabled=true \
+    --set daemonset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set daemonset.newrelic.opsteam.licenseKey.secretRef.name="name" \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    1> /dev/null)
+fi
+
+# Statefulset
+if [[ $case == "17" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set traces.enabled=false \
+    --set logs.enabled=false \
+    --set metrics.enabled=true \
+    --set statefulset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set statefulset.newrelic.opsteam.licenseKey.secretRef.name="name" \
+    "../../helm/charts/collectors" \
+    1> /dev/null)
+fi
+# All of the cases are implemented to output an error as a result.
+# If there is no error, the result would be an empty string.
+# -> This means that the test case has failed to validate.
 if [[ $result != "" ]]; then
   echo "Validation failed!"
   exit 1

--- a/tests/scripts/01_test_helm_inputs.sh
+++ b/tests/scripts/01_test_helm_inputs.sh
@@ -53,6 +53,7 @@ if [[ $case == "03" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
     --set traces.enabled=true \
     --set deployment.newrelic=null \
     --set logs.enabled=false \
@@ -67,6 +68,7 @@ if [[ $case == "04" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
     --set traces.enabled=false \
     --set logs.enabled=true \
     --set daemonset.newrelic=null \
@@ -81,7 +83,8 @@ if [[ $case == "05" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
-    --set traces.enabled=true \
+    --set global.newrelic.enabled=false \
+    --set traces.enabled=false \
     --set logs.enabled=false \
     --set metrics.enabled=true \
     --set statefulset.newrelic=null \
@@ -89,7 +92,7 @@ if [[ $case == "05" ]]; then
     2> /dev/null)
 fi
 
-### Case 06, 07, 08 - OTLP endpoint should be valid
+### Case 06, 07, 08 - OTLP endpoint should be valid (global)
 
 # Deployment
 if [[ $case == "06" ]]; then
@@ -97,8 +100,9 @@ if [[ $case == "06" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="INVALID_ENDPOINT" \
     --set traces.enabled=true \
-    --set deployment.newrelic.opsteam.endpoint="INVALID_ENDPOINT" \
     --set logs.enabled=false \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
@@ -111,9 +115,10 @@ if [[ $case == "07" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="INVALID_ENDPOINT" \
     --set traces.enabled=false \
     --set logs.enabled=true \
-    --set daemonset.newrelic.opsteam.endpoint="INVALID_ENDPOINT" \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
     2> /dev/null)
@@ -125,15 +130,16 @@ if [[ $case == "08" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
-    --set traces.enabled=true \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="INVALID_ENDPOINT" \
+    --set traces.enabled=false \
     --set logs.enabled=false \
     --set metrics.enabled=true \
-    --set daemonsetstatefulset.newrelic.opsteam.endpoint="INVALID_ENDPOINT" \
     "../../helm/charts/collectors" \
     2> /dev/null)
 fi
 
-### Case 09, 10, 11 - License key should be defined
+### Case 09, 10, 11 - OTLP endpoint should be valid (individual)
 
 # Deployment
 if [[ $case == "09" ]]; then
@@ -141,8 +147,9 @@ if [[ $case == "09" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
     --set traces.enabled=true \
-    --set deployment.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set deployment.newrelic.opsteam.endpoint="INVALID_ENDPOINT" \
     --set logs.enabled=false \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
@@ -155,9 +162,10 @@ if [[ $case == "10" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
     --set traces.enabled=false \
     --set logs.enabled=true \
-    --set daemonset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set daemonset.newrelic.opsteam.endpoint="INVALID_ENDPOINT" \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
     2> /dev/null)
@@ -169,15 +177,16 @@ if [[ $case == "11" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
     --set traces.enabled=false \
     --set logs.enabled=false \
     --set metrics.enabled=true \
-    --set statefulset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set statefulset.newrelic.opsteam.endpoint="INVALID_ENDPOINT" \
     "../../helm/charts/collectors" \
     2> /dev/null)
 fi
 
-### Case 12, 13, 14 - License key reference should have a name
+### Case 12, 13, 14 - License key should be defined (global)
 
 # Deployment
 if [[ $case == "12" ]]; then
@@ -185,9 +194,9 @@ if [[ $case == "12" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="otlp.nr-data.net:4317" \
     --set traces.enabled=true \
-    --set deployment.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
-    --set deployment.newrelic.opsteam.licenseKey.secretRef.key="key" \
     --set logs.enabled=false \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
@@ -200,10 +209,10 @@ if [[ $case == "13" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="otlp.nr-data.net:4317" \
     --set traces.enabled=false \
     --set logs.enabled=true \
-    --set daemonset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
-    --set daemonset.newrelic.opsteam.licenseKey.secretRef.key="key" \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
     2> /dev/null)
@@ -215,16 +224,17 @@ if [[ $case == "14" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="otlp.nr-data.net:4317" \
     --set traces.enabled=false \
     --set logs.enabled=false \
     --set metrics.enabled=true \
     --set statefulset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
-    --set statefulset.newrelic.opsteam.licenseKey.secretRef.key="key" \
     "../../helm/charts/collectors" \
     2> /dev/null)
 fi
 
-### Case 15, 16, 17 - License key reference should have a key
+### Case 15, 16, 17 - License key should be defined (individual)
 
 # Deployment
 if [[ $case == "15" ]]; then
@@ -234,7 +244,6 @@ if [[ $case == "15" ]]; then
     --set clusterName=$clusterName \
     --set traces.enabled=true \
     --set deployment.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
-    --set deployment.newrelic.opsteam.licenseKey.secretRef.name="name" \
     --set logs.enabled=false \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
@@ -250,7 +259,6 @@ if [[ $case == "16" ]]; then
     --set traces.enabled=false \
     --set logs.enabled=true \
     --set daemonset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
-    --set daemonset.newrelic.opsteam.licenseKey.secretRef.name="name" \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
     2> /dev/null)
@@ -262,6 +270,205 @@ if [[ $case == "17" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
+    --set traces.enabled=false \
+    --set logs.enabled=false \
+    --set metrics.enabled=true \
+    --set statefulset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+### Case 18, 19, 20 - License key reference should have a name (global)
+
+# Deployment
+if [[ $case == "18" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="otlp.nr-data.net:4317" \
+    --set global.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
+    --set traces.enabled=true \
+    --set logs.enabled=false \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+# Daemonset
+if [[ $case == "19" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="otlp.nr-data.net:4317" \
+    --set global.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
+    --set traces.enabled=false \
+    --set logs.enabled=true \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+# Statefulset
+if [[ $case == "20" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="otlp.nr-data.net:4317" \
+    --set global.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
+    --set traces.enabled=false \
+    --set logs.enabled=false \
+    --set metrics.enabled=true \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+### Case 21, 22, 23 - License key reference should have a name (individual)
+
+# Deployment
+if [[ $case == "21" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
+    --set traces.enabled=true \
+    --set deployment.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set deployment.newrelic.opsteam.licenseKey.secretRef.key="key" \
+    --set logs.enabled=false \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+# Daemonset
+if [[ $case == "22" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
+    --set traces.enabled=false \
+    --set logs.enabled=true \
+    --set daemonset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set daemonset.newrelic.opsteam.licenseKey.secretRef.key="key" \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+# Statefulset
+if [[ $case == "23" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
+    --set traces.enabled=false \
+    --set logs.enabled=false \
+    --set metrics.enabled=true \
+    --set statefulset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set statefulset.newrelic.opsteam.licenseKey.secretRef.key="key" \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+### Case 24, 25, 26 - License key reference should have a key (global)
+
+# Deployment
+if [[ $case == "24" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="otlp.nr-data.net:4317" \
+    --set global.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
+    --set traces.enabled=true \
+    --set logs.enabled=false \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+# Daemonset
+if [[ $case == "25" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="otlp.nr-data.net:4317" \
+    --set global.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
+    --set traces.enabled=false \
+    --set logs.enabled=true \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+# Statefulset
+if [[ $case == "26" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=true \
+    --set global.newrelic.endpoint="otlp.nr-data.net:4317" \
+    --set global.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
+    --set traces.enabled=false \
+    --set logs.enabled=false \
+    --set metrics.enabled=true \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+### Case 27, 28, 29 - License key reference should have a key (individual)
+
+# Deployment
+if [[ $case == "27" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
+    --set traces.enabled=true \
+    --set deployment.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set deployment.newrelic.opsteam.licenseKey.secretRef.name="name" \
+    --set logs.enabled=false \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+# Daemonset
+if [[ $case == "28" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
+    --set traces.enabled=false \
+    --set logs.enabled=true \
+    --set daemonset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
+    --set daemonset.newrelic.opsteam.licenseKey.secretRef.name="name" \
+    --set metrics.enabled=false \
+    "../../helm/charts/collectors" \
+    2> /dev/null)
+fi
+
+# Statefulset
+if [[ $case == "29" ]]; then
+  result=$(helm template ${otelcollectors[name]} \
+    --create-namespace \
+    --namespace ${otelcollectors[namespace]} \
+    --set clusterName=$clusterName \
+    --set global.newrelic.enabled=false \
     --set traces.enabled=false \
     --set logs.enabled=false \
     --set metrics.enabled=true \

--- a/tests/scripts/01_test_helm_inputs.sh
+++ b/tests/scripts/01_test_helm_inputs.sh
@@ -191,7 +191,7 @@ if [[ $case == "12" ]]; then
     --set logs.enabled=false \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
-    1> /dev/null)
+    2> /dev/null)
 fi
 
 # Daemonset
@@ -206,7 +206,7 @@ if [[ $case == "13" ]]; then
     --set daemonset.newrelic.opsteam.licenseKey.secretRef.key="key" \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
-    1> /dev/null)
+    2> /dev/null)
 fi
 
 # Statefulset
@@ -221,7 +221,7 @@ if [[ $case == "14" ]]; then
     --set statefulset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
     --set statefulset.newrelic.opsteam.licenseKey.secretRef.key="key" \
     "../../helm/charts/collectors" \
-    1> /dev/null)
+    2> /dev/null)
 fi
 
 ### Case 15, 16, 17 - License key reference should have a key
@@ -238,7 +238,7 @@ if [[ $case == "15" ]]; then
     --set logs.enabled=false \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
-    1> /dev/null)
+    2> /dev/null)
 fi
 
 # Daemonset
@@ -253,7 +253,7 @@ if [[ $case == "16" ]]; then
     --set daemonset.newrelic.opsteam.licenseKey.secretRef.name="name" \
     --set metrics.enabled=false \
     "../../helm/charts/collectors" \
-    1> /dev/null)
+    2> /dev/null)
 fi
 
 # Statefulset
@@ -268,8 +268,9 @@ if [[ $case == "17" ]]; then
     --set statefulset.newrelic.opsteam.endpoint="otlp.nr-data.net:4317" \
     --set statefulset.newrelic.opsteam.licenseKey.secretRef.name="name" \
     "../../helm/charts/collectors" \
-    1> /dev/null)
+    2> /dev/null)
 fi
+
 # All of the cases are implemented to output an error as a result.
 # If there is no error, the result would be an empty string.
 # -> This means that the test case has failed to validate.


### PR DESCRIPTION
## Changes

- Global config section is added to enable simplified multi-account export for all telemetry data types.
- Global acount export tests are implemented.
- New Relic accounts sections within individual collector types (deployment, daemonset & statefulset) are moved under `teams` sub-section to have unified config with global section.
- Traces are disabled by default in `01_deploy_collectors.sh` easy start script since they are currently not well configured.