### PR TITLE
Implemented deployment collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Kubernetes Monitoring with Open Telemetry
 
-This repository is dedicated to provide a quick start to monitor you Kubernetes cluster. It is designed to be as scalable as possible with the further functionality of exporting necessary telemetry data to multiple New Relic accounts.
+This repository is dedicated to provide a quick start to monitor you Kubernetes cluster. It is designed to be as scalable as possible with the further functionality of exporting necessary telemetry data to multiple New Relic accounts. If want to know where the repo is headed, check out the [roadmap](https://github.com/users/utr1903/projects/1/views/2)!
 
-The collection telemetry data (`logs`, `traces` and `metrics`) is achieved per Open Telemetry collectors configured and deployed as following Kubernetes resources:
+The collection of telemetry data (`logs`, `traces` and `metrics`) is achieved per Open Telemetry collectors configured and deployed as following Kubernetes resources:
 
 - Daemonset
 - Deployment
@@ -20,9 +20,14 @@ The daemonset is primarily used to gather the logs of the applications. It uses 
 
 ### Deployment
 
-The deployment is primarily used to gather the traces per the `otlprecevier` and therefore consists of 2 separate deployments as `recevier` and `exporter`. The reason for this is that the traces are mostly to be sampled and sampling works properly only when all the spans of a trace are processed by one collector instance.
+The deployment is primarily used to gather the application traces & metrics per the `otlprecevier` and consists of 2 separate deployments as `recevier` and `sampler`.
 
-The `receiver` collector is responsible for gathering all of the spans from different applications. It will forward these spans per the `loadbalancingexporter` to the `exporter` collector where they will be sampled according to their trace IDs. The `exporter` collector will then flush the sampled spans to necessary New Relic accounts. Please see official Open Telemetry [docs](https://opentelemetry.io/docs/collector/scaling/#scaling-stateful-collectors) for more!
+The `receiver` collector is responsible of collecting the traces and metrics where
+
+- the metrics are enriched (& filtered if necessary) and will be directly exported to the corresponding New Relic accounts.
+- the traces, on the other hand, are enriched as well but will be exported to the `sampler` collector.
+
+The reason for this is that the traces are mostly to be sampled and sampling works properly only when all the spans of a trace are processed by one collector instance. Therefore, the `loadbalancingexporter` is used to send all spans of a trace to one `sampler` collector instance. After sampling, the `sampler` collector will flush all the spans to necessary New Relic accounts. Please see official Open Telemetry [docs](https://opentelemetry.io/docs/collector/scaling/#scaling-stateful-collectors) for more!
 
 ### Statefulset
 

--- a/helm/charts/collectors/templates/_helpers.tpl
+++ b/helm/charts/collectors/templates/_helpers.tpl
@@ -14,11 +14,11 @@ Set name for deployment collectors.
 {{- define "nrotel.deploymentNameReceiver" -}}
 {{- printf "%s-%s" (include "nrotel.deploymentName" .) "rec" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- define "nrotel.deploymentNameExporter" -}}
-{{- printf "%s-%s" (include "nrotel.deploymentName" .) "exp" | trunc 63 | trimSuffix "-" -}}
+{{- define "nrotel.deploymentNameSampler" -}}
+{{- printf "%s-%s" (include "nrotel.deploymentName" .) "smp" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-{{- define "nrotel.headlessServiceNameExporter" -}}
-{{- printf "%s-%s.%s.%s" (include "nrotel.deploymentNameExporter" .) "collector-headless" .Release.Namespace "svc.cluster.local" | trimSuffix "-" -}}
+{{- define "nrotel.headlessServiceNameSampler" -}}
+{{- printf "%s-%s.%s.%s" (include "nrotel.deploymentNameSampler" .) "collector-headless" .Release.Namespace "svc.cluster.local" | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -46,24 +46,42 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-  {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
-  {{- if eq $teamName "opsteam" }}
+  {{- if .Values.global.newrelic.enabled }}
+    {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
     - name: {{ $teamName }}-endpoint
-      value: {{ $teamInfo.endpoint }}
-    {{- if $teamInfo.licenseKey.secretRef }}
+      value: {{ $.Values.global.newrelic.endpoint }}
+      {{- if $teamInfo.licenseKey.secretRef }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
           name: {{ $teamInfo.licenseKey.secretRef.name }}
           key: {{ $teamInfo.licenseKey.secretRef.key }}
-    {{- else if $teamInfo.licenseKey.value }}
+      {{- else if $teamInfo.licenseKey.value }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
           name: {{ include "nrotel.deploymentName" $ }}-{{ $teamName }}
           key: licenseKey
+      {{- end }}
     {{- end }}
-  {{- end }}
+  {{- else }}
+    {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+    - name: {{ $teamName }}-endpoint
+      value: {{ $teamInfo.endpoint }}
+      {{- if $teamInfo.licenseKey.secretRef }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ $teamInfo.licenseKey.secretRef.name }}
+          key: {{ $teamInfo.licenseKey.secretRef.key }}
+      {{- else if $teamInfo.licenseKey.value }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "nrotel.deploymentName" $ }}-{{ $teamName }}
+          key: licenseKey
+      {{- end }}
+    {{- end }}
   {{- end }}
 
   # Otel configuration
@@ -131,6 +149,43 @@ spec:
           - key: k8s.pod.name
             value: $MY_POD_NAME
             action: upsert
+    {{- if .Values.global.newrelic.enabled }}
+      {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
+        {{- if ne (len $teamInfo.namespaces) 0 }}
+      filter/{{ $teamName }}:
+        error_mode: ignore
+        logs:
+          log_record:
+          {{ $conditionForK8sNamespaceName := "" -}}
+          {{- range $index, $namespace := $teamInfo.namespaces -}}
+            {{- if eq $index 0 -}}
+              {{- $conditionForK8sNamespaceName = printf "resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $namespace -}}
+            {{ else }}
+              {{- $conditionForK8sNamespaceName = printf "%s and resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $conditionForK8sNamespaceName $namespace -}}
+            {{- end -}}
+          {{- end -}}
+            - '{{ $conditionForK8sNamespaceName }}'
+        {{- end }}
+      {{- end }}
+    {{- else }}
+      {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+        {{- if ne (len $teamInfo.namespaces) 0 }}
+      filter/{{ $teamName }}:
+        error_mode: ignore
+        logs:
+          log_record:
+          {{ $conditionForK8sNamespaceName := "" -}}
+          {{- range $index, $namespace := $teamInfo.namespaces -}}
+            {{- if eq $index 0 -}}
+              {{- $conditionForK8sNamespaceName = printf "resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $namespace -}}
+            {{ else }}
+              {{- $conditionForK8sNamespaceName = printf "%s and resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $conditionForK8sNamespaceName $namespace -}}
+            {{- end -}}
+          {{- end -}}
+            - '{{ $conditionForK8sNamespaceName }}'
+        {{- end }}
+      {{- end }}
+    {{- end }}
       memory_limiter:
          check_interval: 1s
          limit_percentage: 80
@@ -149,12 +204,25 @@ spec:
         resolver:
           dns:
             hostname: "{{ include "nrotel.headlessServiceNameExporter" . }}"
-      otlp/opsteam:
-        endpoint: ${opsteam-endpoint}
+    {{- if .Values.global.newrelic.enabled }}
+      {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
+      otlp/{{ $teamName }}:
+        endpoint: ${env:{{ $teamName }}-endpoint}
         tls:
           insecure: false
         headers:
-          api-key: ${opsteam-licenseKey}
+          api-key: ${env:{{ $teamName }}-licenseKey}
+      {{- end }}
+    {{- else }}
+      {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+      otlp/{{ $teamName }}:
+        endpoint: ${env:{{ $teamName }}-endpoint}
+        tls:
+          insecure: false
+        headers:
+          api-key: ${env:{{ $teamName }}-licenseKey}
+      {{- end }}
+    {{- end }}
       logging:
         verbosity: detailed
 
@@ -179,7 +247,9 @@ spec:
           exporters:
             - otlp/opsteam
             # - logging
-        metrics:
+      {{- if .Values.global.newrelic.enabled }}
+        {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
+        metrics/{{ $teamName }}:
           receivers:
             - otlp
           processors:
@@ -187,10 +257,33 @@ spec:
             - k8sattributes
             - attributes
             - memory_limiter
+          {{- if ne (len $teamInfo.namespaces) 0 }}
+            - filter/{{ $teamName }}
+          {{- end }}
             - batch
           exporters:
-            - otlp/opsteam
+            - otlp/{{ $teamName }}
             # - logging
+        {{- end }}
+      {{- else }}
+        {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+        metrics/{{ $teamName }}:
+          receivers:
+            - otlp
+          processors:
+            - cumulativetodelta
+            - k8sattributes
+            - attributes
+            - memory_limiter
+          {{- if ne (len $teamInfo.namespaces) 0 }}
+            - filter/{{ $teamName }}
+          {{- end }}
+            - batch
+          exporters:
+            - otlp/{{ $teamName }}
+            # - logging
+        {{- end }}
+      {{- end }}
         traces:
           receivers:
             - otlp

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -203,7 +203,7 @@ spec:
               insecure: true
         resolver:
           dns:
-            hostname: "{{ include "nrotel.headlessServiceNameExporter" . }}"
+            hostname: "{{ include "nrotel.headlessServiceNameSampler" . }}"
     {{- if .Values.global.newrelic.enabled }}
       {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
       otlp/{{ $teamName }}:

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -149,13 +149,13 @@ spec:
           - key: k8s.pod.name
             value: $MY_POD_NAME
             action: upsert
-    {{- if .Values.global.newrelic.enabled }}
-      {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
-        {{- if ne (len $teamInfo.namespaces) 0 }}
+      {{- if .Values.global.newrelic.enabled }}
+        {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
+          {{- if ne (len $teamInfo.namespaces) 0 }}
       filter/{{ $teamName }}:
         error_mode: ignore
-        logs:
-          log_record:
+        metrics:
+          datapoint:
           {{ $conditionForK8sNamespaceName := "" -}}
           {{- range $index, $namespace := $teamInfo.namespaces -}}
             {{- if eq $index 0 -}}
@@ -165,15 +165,15 @@ spec:
             {{- end -}}
           {{- end -}}
             - '{{ $conditionForK8sNamespaceName }}'
+          {{- end }}
         {{- end }}
-      {{- end }}
-    {{- else }}
-      {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
-        {{- if ne (len $teamInfo.namespaces) 0 }}
+      {{- else }}
+        {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+          {{- if ne (len $teamInfo.namespaces) 0 }}
       filter/{{ $teamName }}:
         error_mode: ignore
-        logs:
-          log_record:
+        metrics:
+          datapoint:
           {{ $conditionForK8sNamespaceName := "" -}}
           {{- range $index, $namespace := $teamInfo.namespaces -}}
             {{- if eq $index 0 -}}
@@ -183,9 +183,9 @@ spec:
             {{- end -}}
           {{- end -}}
             - '{{ $conditionForK8sNamespaceName }}'
+          {{- end }}
         {{- end }}
       {{- end }}
-    {{- end }}
       memory_limiter:
          check_interval: 1s
          limit_percentage: 80

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -46,21 +46,41 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-  {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+  {{- if .Values.global.newrelic.enabled }}
+    {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
     - name: {{ $teamName }}-endpoint
-      value: {{ $teamInfo.endpoint }}
-    {{- if $teamInfo.licenseKey.secretRef }}
+      value: {{ $.Values.global.newrelic.endpoint }}
+      {{- if $teamInfo.licenseKey.secretRef }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
           name: {{ $teamInfo.licenseKey.secretRef.name }}
           key: {{ $teamInfo.licenseKey.secretRef.key }}
-    {{- else if $teamInfo.licenseKey.value }}
+      {{- else if $teamInfo.licenseKey.value }}
     - name: {{ $teamName }}-licenseKey
       valueFrom:
         secretKeyRef:
           name: {{ include "nrotel.deploymentName" $ }}-{{ $teamName }}
           key: licenseKey
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+    - name: {{ $teamName }}-endpoint
+      value: {{ $teamInfo.endpoint }}
+      {{- if $teamInfo.licenseKey.secretRef }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ $teamInfo.licenseKey.secretRef.name }}
+          key: {{ $teamInfo.licenseKey.secretRef.key }}
+      {{- else if $teamInfo.licenseKey.value }}
+    - name: {{ $teamName }}-licenseKey
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "nrotel.deploymentName" $ }}-{{ $teamName }}
+          key: licenseKey
+      {{- end }}
     {{- end }}
   {{- end }}
 
@@ -94,22 +114,6 @@ spec:
 
     processors:
       cumulativetodelta:
-      k8sattributes:
-        extract:
-          metadata:
-          - k8s.node.name
-          - k8s.namespace.name
-          - k8s.pod.name
-        passthrough: false
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.ip
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: connection
       attributes:
         actions:
           - key: k8s.cluster.name
@@ -129,16 +133,42 @@ spec:
           - key: k8s.pod.name
             value: $MY_POD_NAME
             action: upsert
-      {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
-      {{- if ne (len $teamInfo.namespaces) 0 }}
+      {{- if .Values.global.newrelic.enabled }}
+        {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
+          {{- if ne (len $teamInfo.namespaces) 0 }}
       filter/{{ $teamName }}:
         error_mode: ignore
-        metrics:
-          datapoint:
-          {{- range $namespace := $teamInfo.namespaces }}
-            - 'attributes["k8s.namespace.name"] != "{{ $namespace }}"'
+        traces:
+          span:
+          {{ $conditionForK8sNamespaceName := "" -}}
+          {{- range $index, $namespace := $teamInfo.namespaces -}}
+            {{- if eq $index 0 -}}
+              {{- $conditionForK8sNamespaceName = printf "resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $namespace -}}
+            {{ else }}
+              {{- $conditionForK8sNamespaceName = printf "%s and resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $conditionForK8sNamespaceName $namespace -}}
+            {{- end -}}
+          {{- end -}}
+            - '{{ $conditionForK8sNamespaceName }}'
           {{- end }}
-      {{- end }}
+        {{- end }}
+      {{- else }}
+        {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+          {{- if ne (len $teamInfo.namespaces) 0 }}
+      filter/{{ $teamName }}:
+        error_mode: ignore
+        traces:
+          span:
+          {{ $conditionForK8sNamespaceName := "" -}}
+          {{- range $index, $namespace := $teamInfo.namespaces -}}
+            {{- if eq $index 0 -}}
+              {{- $conditionForK8sNamespaceName = printf "resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $namespace -}}
+            {{ else }}
+              {{- $conditionForK8sNamespaceName = printf "%s and resource.attributes[\"k8s.namespace.name\"] != \"%s\"" $conditionForK8sNamespaceName $namespace -}}
+            {{- end -}}
+          {{- end -}}
+            - '{{ $conditionForK8sNamespaceName }}'
+          {{- end }}
+        {{- end }}
       {{- end }}
       memory_limiter:
          check_interval: 1s
@@ -150,13 +180,24 @@ spec:
         send_batch_size : 800
 
     exporters:
-    {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+    {{- if .Values.global.newrelic.enabled }}
+      {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
       otlp/{{ $teamName }}:
         endpoint: ${env:{{ $teamName }}-endpoint}
         tls:
           insecure: false
         headers:
           api-key: ${env:{{ $teamName }}-licenseKey}
+      {{- end }}
+    {{- else }}
+      {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+      otlp/{{ $teamName }}:
+        endpoint: ${env:{{ $teamName }}-endpoint}
+        tls:
+          insecure: false
+        headers:
+          api-key: ${env:{{ $teamName }}-licenseKey}
+      {{- end }}
     {{- end }}
       logging:
         verbosity: detailed
@@ -174,7 +215,6 @@ spec:
             - prometheus/self
           processors:
             - cumulativetodelta
-            - k8sattributes
             - attributes
             - attributes/self
             - memory_limiter
@@ -182,12 +222,12 @@ spec:
           exporters:
             - otlp/opsteam
             # - logging
-      {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+      {{- if .Values.global.newrelic.enabled }}
+        {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
         traces/{{ $teamName }}:
           receivers:
             - otlp
           processors:
-            - k8sattributes
             - attributes
             - memory_limiter
           {{- if ne (len $teamInfo.namespaces) 0 }}
@@ -197,6 +237,23 @@ spec:
           exporters:
             - otlp/{{ $teamName }}
             # - logging
+        {{- end }}
+      {{- else }}
+        {{- range $teamName, $teamInfo := .Values.deployment.newrelic.teams }}
+        traces/{{ $teamName }}:
+          receivers:
+            - otlp
+          processors:
+            - attributes
+            - memory_limiter
+          {{- if ne (len $teamInfo.namespaces) 0 }}
+            - filter/{{ $teamName }}
+          {{- end }}
+            - batch
+          exporters:
+            - otlp/{{ $teamName }}
+            # - logging
+        {{- end }}
       {{- end }}
       telemetry:
         # logs:

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -2,7 +2,7 @@
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
-  name: {{ include "nrotel.deploymentNameExporter" . }}
+  name: {{ include "nrotel.deploymentNameSampler" . }}
   namespace: {{ .Release.Namespace }}
 spec:
 
@@ -118,7 +118,7 @@ spec:
       attributes/self:
         actions:
           - key: otelcollector.type
-            value: deployment-exporter
+            value: deployment-sampler
             action: upsert
           - key: k8s.node.name
             value: $MY_NODE_NAME

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -72,16 +72,18 @@ global:
 ### DEPLOYMENT CONFIG ###
 # This configuration creates 2 collectors as Kubernetes deployments:
 # - receiver
-# - exporter
+# - sampler
 
 ## Receiver collector
-# It is responsible for gathering the spans from
-# all of the applications and routing them to the exporter collector
-# according to the trace IDs. This methodology guarantees that all of
-# the spans belonging to particular trace will be sent to one instance
-# of a collector which again guarentees a correct sampling.
+# It is responsible for gathering the metrics & spans from all of the applications.
+# Metrics
+# - They will be filtered according to teams and will be exported to each team's
+#   account.
+# Traces
+# - They will be sent to the sampler collector per the loadbalancingexporter
+#   according to the trace IDs.
 
-## Exporter collector
+## Sampler collector
 # It is responsible to:
 # - gather the spans from the receiver collector
 # - sample them

--- a/helm/scripts/01_deploy_collectors.sh
+++ b/helm/scripts/01_deploy_collectors.sh
@@ -116,7 +116,7 @@ else
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
-    --set traces.enabled=false \
+    --set traces.enabled=true \
     --set deployment.ports.prometheus.port=${otelcollectors[deploymentPrometheusPort]} \
     --set deployment.newrelic.teams.opsteam.endpoint=$newrelicOtlpEndpoint \
     --set deployment.newrelic.teams.opsteam.licenseKey.value=$NEWRELIC_LICENSE_KEY \


### PR DESCRIPTION
## Changes

- The `exporter` collector is renamed to `sampler` collector.
- Global account config is implemented to both deployment collectors.
- Metrics are being received, filtered and exported by the `receiver` collector.
- Traces are being received by the `receiver` collector and being filtered and exported by the `sampler` collector.
- Traces are enabled again by default.